### PR TITLE
Configure MLflow Ceph S3 artifact storage

### DIFF
--- a/mlops/mlflow/argo-app.yaml
+++ b/mlops/mlflow/argo-app.yaml
@@ -17,8 +17,8 @@ spec:
         valueFiles:
           - $values/mlops/mlflow/helm/values.yaml
     - repoURL: https://github.com/ai-cfia/howard-on-prem.git
-      targetRevision: configure-mlflow-blob-storage
+      targetRevision: refs/heads/configure-mlflow-blob-storage
       ref: values
     - repoURL: https://github.com/ai-cfia/howard-on-prem.git
       path: mlops/mlflow/base
-      targetRevision: configure-mlflow-blob-storage
+      targetRevision: refs/heads/configure-mlflow-blob-storage

--- a/mlops/mlflow/argo-app.yaml
+++ b/mlops/mlflow/argo-app.yaml
@@ -17,8 +17,8 @@ spec:
         valueFiles:
           - $values/mlops/mlflow/helm/values.yaml
     - repoURL: https://github.com/ai-cfia/howard-on-prem.git
-      targetRevision: refs/heads/configure-mlflow-blob-storage
+      targetRevision: HEAD
       ref: values
     - repoURL: https://github.com/ai-cfia/howard-on-prem.git
       path: mlops/mlflow/base
-      targetRevision: refs/heads/configure-mlflow-blob-storage
+      targetRevision: HEAD

--- a/mlops/mlflow/argo-app.yaml
+++ b/mlops/mlflow/argo-app.yaml
@@ -17,8 +17,8 @@ spec:
         valueFiles:
           - $values/mlops/mlflow/helm/values.yaml
     - repoURL: https://github.com/ai-cfia/howard-on-prem.git
-      targetRevision: HEAD
+      targetRevision: configure-mlflow-blob-storage
       ref: values
     - repoURL: https://github.com/ai-cfia/howard-on-prem.git
       path: mlops/mlflow/base
-      targetRevision: HEAD
+      targetRevision: configure-mlflow-blob-storage

--- a/mlops/mlflow/base/secret.yaml
+++ b/mlops/mlflow/base/secret.yaml
@@ -12,3 +12,7 @@ spec:
   dataFrom:
     - extract:
         key: devsecops/cloudnativepg/mlflow-user-creds
+    # Add AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGE_ACCESS_KEY at this
+    # Vault path so MLflow can authenticate to Azure Blob artifact storage.
+    - extract:
+        key: devsecops/mlflow/azure-blob

--- a/mlops/mlflow/base/secret.yaml
+++ b/mlops/mlflow/base/secret.yaml
@@ -12,7 +12,24 @@ spec:
   dataFrom:
     - extract:
         key: devsecops/cloudnativepg/mlflow-user-creds
-    # Add AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGE_ACCESS_KEY at this
-    # Vault path so MLflow can authenticate to Azure Blob artifact storage.
-    - extract:
-        key: devsecops/mlflow/azure-blob
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mlflow-s3-secrets
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-secrets-store
+    kind: ClusterSecretStore
+  target:
+    name: mlflow-s3-secrets
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: secrets/mlflow/s3
+        property: AWS_ACCESS_KEY_ID
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: secrets/mlflow/s3
+        property: AWS_SECRET_ACCESS_KEY

--- a/mlops/mlflow/base/secret.yaml
+++ b/mlops/mlflow/base/secret.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   refreshInterval: "15s"
   secretStoreRef:
-    name: vault-secrets-store
+    name: vault-secret-store
     kind: ClusterSecretStore
   target:
     name: mlflow-s3-secrets

--- a/mlops/mlflow/base/secret.yaml
+++ b/mlops/mlflow/base/secret.yaml
@@ -24,12 +24,6 @@ spec:
     kind: ClusterSecretStore
   target:
     name: mlflow-s3-secrets
-  data:
-    - secretKey: AWS_ACCESS_KEY_ID
-      remoteRef:
+  dataFrom:
+    - extract:
         key: secrets/mlflow/s3
-        property: AWS_ACCESS_KEY_ID
-    - secretKey: AWS_SECRET_ACCESS_KEY
-      remoteRef:
-        key: secrets/mlflow/s3
-        property: AWS_SECRET_ACCESS_KEY

--- a/mlops/mlflow/helm/values.yaml
+++ b/mlops/mlflow/helm/values.yaml
@@ -18,7 +18,7 @@ service:
 # -- Mlflow database connection settings
 backendStore:
   # -- Specifies if you want to run database migration
-  databaseMigration: false
+  databaseMigration: true
 
   # -- Add an additional init container, which checks for database availability
   databaseConnectionCheck: false

--- a/mlops/mlflow/helm/values.yaml
+++ b/mlops/mlflow/helm/values.yaml
@@ -52,6 +52,11 @@ backendStore:
 # Keep this in sync with the public ingress hostname.
 extraEnvVars:
   MLFLOW_SERVER_ALLOWED_HOSTS: "mlflow.inspection.alpha.canada.ca"
+  MLFLOW_SERVER_CORS_ALLOWED_ORIGINS: "https://mlflow.inspection.alpha.canada.ca"
+
+extraFlags:
+  - allowedHosts: "mlflow.inspection.alpha.canada.ca"
+  - corsAllowedOrigins: "https://mlflow.inspection.alpha.canada.ca"
 
 # Add the ExternalSecret-backed Kubernetes Secret to the MLflow pod environment.
 # The secret should include AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGE_ACCESS_KEY.

--- a/mlops/mlflow/helm/values.yaml
+++ b/mlops/mlflow/helm/values.yaml
@@ -54,9 +54,9 @@ extraEnvVars:
   MLFLOW_SERVER_ALLOWED_HOSTS: "mlflow.inspection.alpha.canada.ca"
   MLFLOW_SERVER_CORS_ALLOWED_ORIGINS: "https://mlflow.inspection.alpha.canada.ca"
 
-extraFlags:
-  - allowedHosts: "mlflow.inspection.alpha.canada.ca"
-  - corsAllowedOrigins: "https://mlflow.inspection.alpha.canada.ca"
+extraArgs:
+  allowedHosts: "mlflow.inspection.alpha.canada.ca"
+  corsAllowedOrigins: "https://mlflow.inspection.alpha.canada.ca"
 
 # Add the ExternalSecret-backed Kubernetes Secret to the MLflow pod environment.
 # The secret should include AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGE_ACCESS_KEY.

--- a/mlops/mlflow/helm/values.yaml
+++ b/mlops/mlflow/helm/values.yaml
@@ -51,6 +51,16 @@ backendStore:
     # -- The key of the password in the existing database secret.
     passwordKey: "password"
 
+artifactRoot:
+  s3:
+    enabled: true
+    bucket: "mlflow"
+    path: "artifacts"
+    existingSecret:
+      name: "mlflow-s3-secrets"
+      keyOfAccessKeyId: "AWS_ACCESS_KEY_ID"
+      keyOfSecretAccessKey: "AWS_SECRET_ACCESS_KEY"
+
 # MLflow 3.5+ rejects requests whose Host header is not explicitly trusted.
 # Keep this in sync with the public ingress hostname.
 extraEnvVars:
@@ -58,14 +68,15 @@ extraEnvVars:
   MLFLOW_SERVER_CORS_ALLOWED_ORIGINS: "https://mlflow.inspection.alpha.canada.ca"
   MLFLOW_SQLALCHEMYSTORE_POOL_SIZE: "2"
   MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW: "0"
+  MLFLOW_S3_ENDPOINT_URL: "http://rook-ceph-rgw-ceph-hot-objectstore.rook-ceph-hot-cluster.svc.cluster.local:80"
 
 extraArgs:
   allowedHosts: "mlflow.inspection.alpha.canada.ca"
   corsAllowedOrigins: "https://mlflow.inspection.alpha.canada.ca"
   uvicornOpts: "--workers 1"
 
-# Add the ExternalSecret-backed Kubernetes Secret to the MLflow pod environment.
-# The secret should include AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGE_ACCESS_KEY.
+# Add ExternalSecret-backed Kubernetes Secrets to the MLflow pod environment.
+# mlflow-s3-secrets should include AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
 extraSecretNamesForEnvFrom:
   - mlflow-secrets
 

--- a/mlops/mlflow/helm/values.yaml
+++ b/mlops/mlflow/helm/values.yaml
@@ -66,15 +66,14 @@ artifactRoot:
 extraEnvVars:
   MLFLOW_SERVER_ALLOWED_HOSTS: "mlflow.inspection.alpha.canada.ca"
   MLFLOW_SERVER_CORS_ALLOWED_ORIGINS: "https://mlflow.inspection.alpha.canada.ca"
-  MLFLOW_S3_ENDPOINT_URL: "http://rook-ceph-rgw-ceph-hot-objectstore.rook-ceph-hot-cluster.svc.cluster.local:80"
 
 extraArgs:
   allowedHosts: "mlflow.inspection.alpha.canada.ca"
   corsAllowedOrigins: "https://mlflow.inspection.alpha.canada.ca"
   uvicornOpts: "--workers 1"
 
-# Add ExternalSecret-backed Kubernetes Secrets to the MLflow pod environment.
-# mlflow-s3-secrets should include AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+# Add the ExternalSecret-backed Kubernetes Secret to the MLflow pod environment.
+# S3 artifact credentials and endpoint are provided by artifactRoot.s3.existingSecret.
 extraSecretNamesForEnvFrom:
   - mlflow-secrets
 

--- a/mlops/mlflow/helm/values.yaml
+++ b/mlops/mlflow/helm/values.yaml
@@ -56,10 +56,13 @@ backendStore:
 extraEnvVars:
   MLFLOW_SERVER_ALLOWED_HOSTS: "mlflow.inspection.alpha.canada.ca"
   MLFLOW_SERVER_CORS_ALLOWED_ORIGINS: "https://mlflow.inspection.alpha.canada.ca"
+  MLFLOW_SQLALCHEMYSTORE_POOL_SIZE: "2"
+  MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW: "0"
 
 extraArgs:
   allowedHosts: "mlflow.inspection.alpha.canada.ca"
   corsAllowedOrigins: "https://mlflow.inspection.alpha.canada.ca"
+  uvicornOpts: "--workers 1"
 
 # Add the ExternalSecret-backed Kubernetes Secret to the MLflow pod environment.
 # The secret should include AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGE_ACCESS_KEY.

--- a/mlops/mlflow/helm/values.yaml
+++ b/mlops/mlflow/helm/values.yaml
@@ -48,6 +48,16 @@ backendStore:
     # -- The key of the password in the existing database secret.
     passwordKey: "password"
 
+# MLflow 3.5+ rejects requests whose Host header is not explicitly trusted.
+# Keep this in sync with the public ingress hostname.
+extraEnvVars:
+  MLFLOW_SERVER_ALLOWED_HOSTS: "mlflow.inspection.alpha.canada.ca"
+
+# Add the ExternalSecret-backed Kubernetes Secret to the MLflow pod environment.
+# The secret should include AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGE_ACCESS_KEY.
+extraSecretNamesForEnvFrom:
+  - mlflow-secrets
+
 ingress:
   # -- Specifies if you want to create an ingress access
   enabled: true

--- a/mlops/mlflow/helm/values.yaml
+++ b/mlops/mlflow/helm/values.yaml
@@ -1,6 +1,9 @@
 # -- (int) Numbers of replicas
 replicaCount: 1
 
+log:
+  enabled: false
+
 # -- This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
   # -- This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types

--- a/mlops/mlflow/helm/values.yaml
+++ b/mlops/mlflow/helm/values.yaml
@@ -66,8 +66,6 @@ artifactRoot:
 extraEnvVars:
   MLFLOW_SERVER_ALLOWED_HOSTS: "mlflow.inspection.alpha.canada.ca"
   MLFLOW_SERVER_CORS_ALLOWED_ORIGINS: "https://mlflow.inspection.alpha.canada.ca"
-  MLFLOW_SQLALCHEMYSTORE_POOL_SIZE: "2"
-  MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW: "0"
   MLFLOW_S3_ENDPOINT_URL: "http://rook-ceph-rgw-ceph-hot-objectstore.rook-ceph-hot-cluster.svc.cluster.local:80"
 
 extraArgs:

--- a/mlops/mlflow/helm/values.yaml
+++ b/mlops/mlflow/helm/values.yaml
@@ -18,7 +18,7 @@ service:
 # -- Mlflow database connection settings
 backendStore:
   # -- Specifies if you want to run database migration
-  databaseMigration: true
+  databaseMigration: false
 
   # -- Add an additional init container, which checks for database availability
   databaseConnectionCheck: false

--- a/storage/cloudnativepg/base/acia-cfia-dev-cluster/cluster.yaml
+++ b/storage/cloudnativepg/base/acia-cfia-dev-cluster/cluster.yaml
@@ -127,7 +127,7 @@ spec:
         inherit: true
         replication: false
         bypassrls: false
-        connectionLimit: 10
+        connectionLimit: 30
         passwordSecret:
           name: mlflow-user-creds
 


### PR DESCRIPTION
Closes #428

## Summary
- Configure MLflow to store artifacts in the Ceph RGW S3 bucket `mlflow`
- Add `mlflow-s3-secrets` ExternalSecret for S3 credentials from Vault
- Set MLflow S3 endpoint and artifact root
- Fix MLflow invalid Host header errors for `mlflow.inspection.alpha.canada.ca`
- Configure MLflow allowed host/CORS settings for the public ingress hostname
- Use Uvicorn-compatible server args for MLflow 3.7 security middleware
- Increase `mlflow-user` Postgres connection limit from 10 to 30

## Validation
- Confirmed `mlflow-s3-secrets` is created successfully by External Secrets
- Confirmed MLflow pod receives `MLFLOW_S3_ENDPOINT_URL` and S3 credentials
- Verified S3 PUT/GET/DELETE from inside the MLflow pod
- Verified MLflow UI loads through the public ingress hostname
- Verified MLflow can log an artifact successfully through the tracking API

## Notes
- No plaintext credentials are committed
- Credentials are sourced from Vault path `secrets/mlflow/s3`