### PR TITLE
fix: load MLflow S3 endpoint secret into pod env

### DIFF
--- a/mlops/mlflow/helm/values.yaml
+++ b/mlops/mlflow/helm/values.yaml
@@ -72,10 +72,11 @@ extraArgs:
   corsAllowedOrigins: "https://mlflow.inspection.alpha.canada.ca"
   uvicornOpts: "--workers 1"
 
-# Add the ExternalSecret-backed Kubernetes Secret to the MLflow pod environment.
-# S3 artifact credentials and endpoint are provided by artifactRoot.s3.existingSecret.
+# Add ExternalSecret-backed Kubernetes Secrets to the MLflow pod environment.
+# The S3 secret also provides MLFLOW_S3_ENDPOINT_URL from Vault.
 extraSecretNamesForEnvFrom:
   - mlflow-secrets
+  - mlflow-s3-secrets
 
 ingress:
   # -- Specifies if you want to create an ingress access


### PR DESCRIPTION
## Summary
- Load `mlflow-s3-secrets` into the MLflow pod environment
- Allows `MLFLOW_S3_ENDPOINT_URL` to come from Vault automatically

## Validation
- Confirmed merged deployment had S3 keys but `MLFLOW_S3_ENDPOINT_URL=None`
- Manually exported the endpoint inside the pod
- Verified S3 PUT/GET/DELETE succeeds
- Verified MLflow can log an artifact successfully