### PR TITLE
Deploy FiftyOne for dataset curation in annotation workspace

### DIFF
--- a/apps/annotation/base/fiftyone/README.md
+++ b/apps/annotation/base/fiftyone/README.md
@@ -1,0 +1,57 @@
+# FiftyOne
+
+This directory deploys FiftyOne as an internal ML dataset curation and visual
+review workbench.
+
+## Scope
+
+- The FiftyOne app runs as a single-replica Deployment.
+- MongoDB runs as a single-replica StatefulSet and stores FiftyOne metadata.
+- This first pass intentionally skips MongoDB backups, clustering, and
+  hardening so the team can validate the app, database connection, and
+  persistence.
+- Access control is limited to the existing cluster/network controls for this
+  first pass.
+
+## Networking
+
+FiftyOne uses the same shared Gateway pattern as Label Studio. The HTTPRoute
+exposes:
+
+```text
+https://fiftyone.inspection.alpha.canada.ca
+```
+
+The Gateway listener is defined in `apps/louis/base/gateway.yaml`, and the
+HTTPRoute is defined in `apps/annotation/base/httproute.yaml`. DNS should point
+to the shared Gateway IP.
+
+## Storage
+
+FiftyOne metadata is stored in MongoDB. Dataset media should be available to the
+FiftyOne pod through filesystem paths. For S3-compatible storage such as Ceph or
+MinIO, mount or sync the bucket into the pod before importing datasets.
+
+The pod also mounts the annotation shared PVC at `/ailab`, matching the shared
+workspace pattern used by Label Studio and the AI Lab shared work containers.
+
+## Validation
+
+```bash
+kubectl get httproute -n annotation
+kubectl get pods,svc,statefulset,pvc -n annotation
+kubectl logs deploy/fiftyone -n annotation
+kubectl logs statefulset/fiftyone-mongodb -n annotation
+kubectl rollout restart deploy/fiftyone -n annotation
+kubectl port-forward svc/fiftyone 5151:5151 -n annotation
+```
+
+Manual checks:
+
+- Open `https://fiftyone.inspection.alpha.canada.ca`.
+- Confirm the UI loads.
+- Import or attach a small test dataset if appropriate.
+- Restart the FiftyOne pod.
+- Confirm dataset metadata remains available after restart.
+- Restart the MongoDB pod and confirm metadata persists from the StatefulSet
+  volume claim.

--- a/apps/annotation/base/fiftyone/README.md
+++ b/apps/annotation/base/fiftyone/README.md
@@ -6,7 +6,8 @@ review workbench.
 ## Scope
 
 - The FiftyOne app runs as a single-replica Deployment.
-- MongoDB runs as a single-replica StatefulSet and stores FiftyOne metadata.
+- MongoDB is deployed as a shared storage service from `storage/mongodb` and
+  stores FiftyOne metadata.
 - This first pass intentionally skips MongoDB backups, clustering, and
   hardening so the team can validate the app, database connection, and
   persistence.
@@ -28,9 +29,15 @@ to the shared Gateway IP.
 
 ## Storage
 
-FiftyOne metadata is stored in MongoDB. Dataset media should be available to the
-FiftyOne pod through filesystem paths. For S3-compatible storage such as Ceph or
-MinIO, mount or sync the bucket into the pod before importing datasets.
+FiftyOne metadata is stored in the shared MongoDB service:
+
+```text
+mongodb://mongodb.mongodb.svc.cluster.local:27017/fiftyone
+```
+
+Dataset media should be available to the FiftyOne pod through filesystem paths.
+For S3-compatible storage such as Ceph or MinIO, mount or sync the bucket into
+the pod before importing datasets.
 
 The pod also mounts the annotation shared PVC at `/ailab`, matching the shared
 workspace pattern used by Label Studio and the AI Lab shared work containers.
@@ -39,9 +46,10 @@ workspace pattern used by Label Studio and the AI Lab shared work containers.
 
 ```bash
 kubectl get httproute -n annotation
-kubectl get pods,svc,statefulset,pvc -n annotation
+kubectl get pods,svc,pvc -n annotation
+kubectl get pods,svc,statefulset,pvc -n mongodb
 kubectl logs deploy/fiftyone -n annotation
-kubectl logs statefulset/fiftyone-mongodb -n annotation
+kubectl logs statefulset/mongodb -n mongodb
 kubectl rollout restart deploy/fiftyone -n annotation
 kubectl port-forward svc/fiftyone 5151:5151 -n annotation
 ```

--- a/apps/annotation/base/fiftyone/certificates.yaml
+++ b/apps/annotation/base/fiftyone/certificates.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: fiftyone-tls
+  namespace: louis
+spec:
+  secretName: fiftyone-tls
+  duration: 2160h  # 90 days
+  renewBefore: 360h  # 15 days
+  subject:
+    organizations:
+      - ACIA CFIA AI Lab
+  commonName: fiftyone.inspection.alpha.canada.ca
+  dnsNames:
+    - fiftyone.inspection.alpha.canada.ca
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/apps/annotation/base/fiftyone/fiftyone.yaml
+++ b/apps/annotation/base/fiftyone/fiftyone.yaml
@@ -39,7 +39,7 @@ spec:
             - "5151"
           env:
             - name: FIFTYONE_DATABASE_URI
-              value: mongodb://fiftyone-mongodb:27017/fiftyone
+              value: mongodb://mongodb.mongodb.svc.cluster.local:27017/fiftyone
             - name: FIFTYONE_DEFAULT_APP_ADDRESS
               value: 0.0.0.0
             - name: FIFTYONE_DEFAULT_DATASET_DIR

--- a/apps/annotation/base/fiftyone/fiftyone.yaml
+++ b/apps/annotation/base/fiftyone/fiftyone.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fiftyone
+  labels:
+    app.kubernetes.io/name: fiftyone
+    app.kubernetes.io/part-of: fiftyone
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fiftyone
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fiftyone
+        app.kubernetes.io/part-of: fiftyone
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: In
+                    values:
+                      - ai-worker
+      containers:
+        - name: fiftyone
+          image: voxel51/fiftyone:1.15.0-python3.9-20260502
+          imagePullPolicy: IfNotPresent
+          command:
+            - python
+            - -m
+            - fiftyone.server.main
+            - --port
+            - "5151"
+          env:
+            - name: FIFTYONE_DATABASE_URI
+              value: mongodb://fiftyone-mongodb:27017/fiftyone
+            - name: FIFTYONE_DEFAULT_APP_ADDRESS
+              value: 0.0.0.0
+            - name: FIFTYONE_DEFAULT_DATASET_DIR
+              value: /fiftyone/default
+            - name: FIFTYONE_DATASET_ZOO_DIR
+              value: /fiftyone/zoo/datasets
+            - name: FIFTYONE_MODEL_ZOO_DIR
+              value: /fiftyone/zoo/models
+          ports:
+            - containerPort: 5151
+              name: http
+          volumeMounts:
+            - name: workspace
+              mountPath: /fiftyone
+            - name: shared-data
+              mountPath: /ailab
+          startupProbe:
+            httpGet:
+              path: /
+              port: 5151
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 18
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5151
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 5151
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+      volumes:
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: fiftyone-workspace-pvc
+        - name: shared-data
+          persistentVolumeClaim:
+            claimName: labelstudio-shared-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fiftyone-workspace-pvc
+  labels:
+    app.kubernetes.io/name: fiftyone
+    app.kubernetes.io/part-of: fiftyone
+spec:
+  storageClassName: ceph-hot-block
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fiftyone
+  labels:
+    app.kubernetes.io/name: fiftyone
+    app.kubernetes.io/part-of: fiftyone
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: fiftyone
+  ports:
+    - name: http
+      port: 5151
+      targetPort: 5151

--- a/apps/annotation/base/fiftyone/mongodb.yaml
+++ b/apps/annotation/base/fiftyone/mongodb.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: fiftyone-mongodb
+  labels:
+    app.kubernetes.io/name: fiftyone-mongodb
+    app.kubernetes.io/part-of: fiftyone
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  serviceName: fiftyone-mongodb
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fiftyone-mongodb
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fiftyone-mongodb
+        app.kubernetes.io/part-of: fiftyone
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: In
+                    values:
+                      - ai-worker
+      containers:
+        - name: mongodb
+          image: mongo:7.0.26
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - exec mongod --noauth --bind_ip_all
+          ports:
+            - containerPort: 27017
+              name: mongodb
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+          readinessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: fiftyone-mongodb
+          app.kubernetes.io/part-of: fiftyone
+      spec:
+        storageClassName: ceph-hot-block
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fiftyone-mongodb
+  labels:
+    app.kubernetes.io/name: fiftyone-mongodb
+    app.kubernetes.io/part-of: fiftyone
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: fiftyone-mongodb
+  ports:
+    - name: mongodb
+      port: 27017
+      targetPort: 27017

--- a/apps/annotation/base/httproute.yaml
+++ b/apps/annotation/base/httproute.yaml
@@ -18,3 +18,23 @@ spec:
       backendRefs:
         - name: labelstudio-svc
           port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: fiftyone-route
+spec:
+  parentRefs:
+    - name: louis-gateway
+      namespace: louis
+      sectionName: https-fiftyone
+  hostnames:
+    - fiftyone.inspection.alpha.canada.ca
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/"
+      backendRefs:
+        - name: fiftyone
+          port: 5151

--- a/apps/annotation/base/kustomization.yaml
+++ b/apps/annotation/base/kustomization.yaml
@@ -1,12 +1,12 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- labelstudio/pvcs.yaml
-- labelstudio/secrets.yaml
-- labelstudio/labelstudio.yaml
-- labelstudio/certificates.yaml
-- fiftyone/mongodb.yaml
-- fiftyone/fiftyone.yaml
-- fiftyone/certificates.yaml
-- httproute.yaml
+  - labelstudio/pvcs.yaml
+  - labelstudio/secrets.yaml
+  - labelstudio/labelstudio.yaml
+  - labelstudio/certificates.yaml
+  - fiftyone/fiftyone.yaml
+  - fiftyone/certificates.yaml
+  - httproute.yaml

--- a/apps/annotation/base/kustomization.yaml
+++ b/apps/annotation/base/kustomization.yaml
@@ -6,4 +6,7 @@ resources:
 - labelstudio/secrets.yaml
 - labelstudio/labelstudio.yaml
 - labelstudio/certificates.yaml
+- fiftyone/mongodb.yaml
+- fiftyone/fiftyone.yaml
+- fiftyone/certificates.yaml
 - httproute.yaml

--- a/apps/louis/base/gateway.yaml
+++ b/apps/louis/base/gateway.yaml
@@ -80,6 +80,24 @@ spec:
                 operator: In
                 values:
                   - annotation
+    - name: https-fiftyone
+      hostname: fiftyone.inspection.alpha.canada.ca
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: fiftyone-tls
+            kind: Secret
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - annotation
     - name: https-librechat
       hostname: librechat.inspection.alpha.canada.ca
       port: 443

--- a/gitops/argocd-apps/kustomization.yaml
+++ b/gitops/argocd-apps/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -49,6 +50,7 @@ resources:
   - ../../storage/rook-ceph/clusters/rook-ceph-cold-cluster/
   - ../../storage/rook-ceph/clusters/rook-ceph-hot-cluster/
   - ../../storage/cloudnativepg/
+  - ../../storage/mongodb/
   - ../../storage/pgadmin/
   - ../../storage/minio/
   - ../../storage/velero/
@@ -69,7 +71,8 @@ resources:
   # Infrastructure and configuration applications
 
 # This patch enforces a standardized sync policy for Argo CD applications:
-# - Enables automated sync with pruning (removes orphaned resources) and self-healing.
+# - Enables automated sync with pruning (removes orphaned resources) and
+#   self-healing.
 # - Adds a finalizer to ensure proper cascading deletion.
 # - Automatically creates namespaces if they don’t exist.
 # - Retains up to 4 revision history records.

--- a/storage/mongodb/argo-app.yaml
+++ b/storage/mongodb/argo-app.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mongodb
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: default
+  destination:
+    namespace: mongodb
+    server: https://kubernetes.default.svc
+  sources:
+    - repoURL: https://github.com/ai-cfia/howard-on-prem.git
+      path: storage/mongodb/base/
+      targetRevision: HEAD

--- a/storage/mongodb/base/kustomization.yaml
+++ b/storage/mongodb/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - mongodb.yaml

--- a/storage/mongodb/base/mongodb.yaml
+++ b/storage/mongodb/base/mongodb.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: fiftyone-mongodb
+  name: mongodb
   labels:
-    app.kubernetes.io/name: fiftyone-mongodb
-    app.kubernetes.io/part-of: fiftyone
+    app.kubernetes.io/name: mongodb
+    app.kubernetes.io/part-of: storage
 spec:
   replicas: 1
   revisionHistoryLimit: 3
-  serviceName: fiftyone-mongodb
+  serviceName: mongodb-headless
   selector:
     matchLabels:
-      app.kubernetes.io/name: fiftyone-mongodb
+      app.kubernetes.io/name: mongodb
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: fiftyone-mongodb
-        app.kubernetes.io/part-of: fiftyone
+        app.kubernetes.io/name: mongodb
+        app.kubernetes.io/part-of: storage
     spec:
       affinity:
         nodeAffinity:
@@ -59,8 +59,8 @@ spec:
     - metadata:
         name: data
         labels:
-          app.kubernetes.io/name: fiftyone-mongodb
-          app.kubernetes.io/part-of: fiftyone
+          app.kubernetes.io/name: mongodb
+          app.kubernetes.io/part-of: storage
       spec:
         storageClassName: ceph-hot-block
         accessModes:
@@ -72,14 +72,30 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: fiftyone-mongodb
+  name: mongodb
   labels:
-    app.kubernetes.io/name: fiftyone-mongodb
-    app.kubernetes.io/part-of: fiftyone
+    app.kubernetes.io/name: mongodb
+    app.kubernetes.io/part-of: storage
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mongodb
+  ports:
+    - name: mongodb
+      port: 27017
+      targetPort: 27017
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb-headless
+  labels:
+    app.kubernetes.io/name: mongodb
+    app.kubernetes.io/part-of: storage
 spec:
   clusterIP: None
   selector:
-    app.kubernetes.io/name: fiftyone-mongodb
+    app.kubernetes.io/name: mongodb
   ports:
     - name: mongodb
       port: 27017

--- a/storage/mongodb/kustomization.yaml
+++ b/storage/mongodb/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - argo-app.yaml


### PR DESCRIPTION
Relates to #431
## Summary

Adds FiftyOne to the `apps/annotation` workspace as an internal dataset curation and visual review tool.

FiftyOne is deployed with:

- a pinned `voxel51/fiftyone` image
- a single-node MongoDB metadata backend
- persistent MongoDB storage
- access to the shared annotation workspace at `/ailab`
- HTTP routing through the existing `louis-gateway`

## Implementation Notes

FiftyOne is placed under `apps/annotation/base/fiftyone` so it sits beside the existing Label Studio annotation tooling.

Routing follows the active Label Studio pattern by adding an `HTTPRoute` and a new `https-fiftyone` listener on `louis-gateway`, instead of creating a dedicated Cilium Ingress/IP. This avoids relying on `annotation-gateway`, which may have IP conflicts.

FiftyOne metadata is stored in MongoDB. Dataset media is expected to be available through filesystem paths, especially the shared `/ailab` mount.

## Validation

Ran:

```bash
yamllint apps/annotation/base/fiftyone apps/annotation/base/httproute.yaml
kubectl kustomize apps/annotation/base
kubectl kustomize apps/annotation
kubectl kustomize apps/louis/base
kubectl kustomize gitops/argocd-apps