### PR TITLE
Fix FiftyOne TLS ownership and MongoDB namespace sync

### DIFF
--- a/apps/annotation/base/kustomization.yaml
+++ b/apps/annotation/base/kustomization.yaml
@@ -8,5 +8,4 @@ resources:
   - labelstudio/labelstudio.yaml
   - labelstudio/certificates.yaml
   - fiftyone/fiftyone.yaml
-  - fiftyone/certificates.yaml
   - httproute.yaml

--- a/apps/louis/base/fiftyone/certificates.yaml
+++ b/apps/louis/base/fiftyone/certificates.yaml
@@ -3,7 +3,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: fiftyone-tls
-  namespace: louis
 spec:
   secretName: fiftyone-tls
   duration: 2160h  # 90 days

--- a/apps/louis/base/kustomization.yaml
+++ b/apps/louis/base/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - gptresearcher/configmap.yaml
   - gptresearcher/secrets.yaml
   # - gptresearcher/certificates.yaml
+  - fiftyone/certificates.yaml
   - bridge-gptr/deployment.yaml
   - bridge-gptr/secrets.yaml
   - bridge-gptr/certificates.yaml

--- a/storage/mongodb/argo-app.yaml
+++ b/storage/mongodb/argo-app.yaml
@@ -15,3 +15,9 @@ spec:
     - repoURL: https://github.com/ai-cfia/howard-on-prem.git
       path: storage/mongodb/base/
       targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Relates to #431

## Summary

Follow-up fix for the FiftyOne deployment.

This PR:
- moves `Certificate/fiftyone-tls` from the annotation app to the Louis app, so the certificate is owned by the same app as `louis-gateway`
- keeps `HTTPRoute/fiftyone-route` in the annotation app, where the FiftyOne Service lives
- adds `CreateNamespace=true` directly to the MongoDB Argo CD app so the `mongodb` namespace is created during sync

## Why

Live validation showed that MongoDB and FiftyOne internal connectivity were working, but the public URL was blocked because the `https-fiftyone` listener on `louis-gateway` could not find `Secret/fiftyone-tls`.

The certificate existed in the louis namespace, but it was tracked by the annotation app while the Gateway consuming the secret is managed by the Louis app. Moving the certificate to Louis gives cleaner GitOps ownership and should prevent the Gateway from being degraded due to a missing TLS secret.

MongoDB also needed `CreateNamespace=true` so the `mongodb` namespace is created automatically by Argo CD.

## Validation

Ran:

```bash
yamllint storage/mongodb apps/louis/base/fiftyone apps/louis/base/kustomization.yaml apps/annotation/base/kustomization.yaml
kubectl kustomize apps/louis/base
kubectl kustomize apps/annotation/base
kubectl kustomize storage/mongodb