### PR TITLE
 Deploy signed Nachet backend staging image

### DIFF
--- a/apps/nachet-dev/base/nachet-staging-op-deployment.yml
+++ b/apps/nachet-dev/base/nachet-staging-op-deployment.yml
@@ -45,7 +45,7 @@ spec:
                       - ai-lab-4
       containers:
         - name: nachet-staging-op
-          image: ghcr.io/ai-cfia/nachet-backend:2.4.0
+          image: ghcr.io/ai-cfia/nachet-backend:2.9.13
           command: ["/bin/sh", "-c"]
           args: ["uv run hypercorn -b :8080 app/main:app"]
           imagePullPolicy: Always


### PR DESCRIPTION
## Summary

Update the Nachet staging backend deployment to use a signed backend image.

## Context

The current staging image `ghcr.io/ai-cfia/nachet-backend:2.4.0` is unsigned and is rejected by the cluster Sigstore policy.

The replacement image `ghcr.io/ai-cfia/nachet-backend:2.9.13` verifies successfully with Cosign.

## Verification

- Verified `ghcr.io/ai-cfia/nachet-backend:2.9.13` with Cosign.
- Signature identity is from `ai-cfia/nachet` GitHub Actions OIDC.