### PR TITLE
Deploy signed Nachet prod backend image

### DIFF
--- a/apps/nachet-prod/base/nachet-prod-op-deployment.yml
+++ b/apps/nachet-prod/base/nachet-prod-op-deployment.yml
@@ -45,7 +45,7 @@ spec:
                       - ai-lab-2
       containers:
         - name: nachet-prod-op
-          image: ghcr.io/ai-cfia/nachet-backend:2.4.0
+          image: ghcr.io/ai-cfia/nachet-backend:2.9.13
           command: ["/bin/sh", "-c"]
           args: ["uv run hypercorn -b :8080 app/main:app"]
           imagePullPolicy: Always


### PR DESCRIPTION
## Summary

Update `nachet-prod-op` to use the signed Nachet backend image `2.9.13`.

## Context

Argo CD is currently blocked because prod still deploys `nachet-backend:2.4.0`, which has no Cosign signature and is rejected by the Sigstore admission policy.

## Verification

- Verified `ghcr.io/ai-cfia/nachet-backend:2.9.13` with Cosign.
- Confirmed the signature uses GitHub Actions OIDC from `ai-cfia/nachet`.