### PR TITLE
Manage Sigstore GitHub Actions policy in GitOps

### DIFF
--- a/security/cosign/base/policy.yaml
+++ b/security/cosign/base/policy.yaml
@@ -1,16 +1,15 @@
-# ---- Created manually ---- 
-# apiVersion: policy.sigstore.dev/v1beta1
-# kind: ClusterImagePolicy
-# metadata:
-#   name: github-actions-policy
-# spec:
-#   images:
-#     - glob: "**"
-#   authorities:
-#     - keyless:
-#         url: https://fulcio.sigstore.dev
-#         identities:
-#           - issuer: https://token.actions.githubusercontent.com
-#             subject: "^https://github.com/ai-cfia/.*$"
-#       ctlog:
-#         url: https://rekor.sigstore.dev
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: github-actions-policy
+spec:
+  images:
+    - glob: "**"
+  authorities:
+    - keyless:
+        url: https://fulcio.sigstore.dev
+        identities:
+          - issuer: https://token.actions.githubusercontent.com
+            subjectRegExp: "^https://github.com/ai-cfia/.*$"
+      ctlog:
+        url: https://rekor.sigstore.dev

--- a/security/cosign/kustomization.yaml
+++ b/security/cosign/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - argo-app.yaml
+  - base/policy.yaml


### PR DESCRIPTION
## Context

The Nachet image is signed now, so the original `no signatures found` error is resolved. Argo is now rejecting it because the signature identity does not match the current cluster policy.

This PR moves the existing manually-created Sigstore policy into Howard GitOps and allows AI-CFIA GitHub Actions signing identities.