### PR TITLE
Add FiftyOne shared dataset sync workflow

### DIFF
--- a/.github/workflows/fiftyone-s3-sync.yml
+++ b/.github/workflows/fiftyone-s3-sync.yml
@@ -10,6 +10,7 @@ name: FiftyOne S3 dataset sync
     paths:
       - .github/workflows/fiftyone-s3-sync.yml
       - apps/annotation/base/fiftyone/s3-sync.yaml
+      - apps/annotation/base/fiftyone/s3-sync-rbac.yaml
       - apps/annotation/base/fiftyone/s3-secrets.yaml
       - apps/annotation/base/kustomization.yaml
   workflow_dispatch:
@@ -51,9 +52,26 @@ jobs:
 
       - name: Check Kubernetes access
         run: |
-          test "$(kubectl auth can-i create jobs -n annotation)" = "yes"
-          test "$(kubectl auth can-i get jobs -n annotation)" = "yes"
-          test "$(kubectl auth can-i get pods/log -n annotation)" = "yes"
+          set -eu
+
+          failed=0
+          for check in \
+            "create jobs" \
+            "get jobs" \
+            "list jobs" \
+            "watch jobs" \
+            "get pods" \
+            "list pods" \
+            "get pods/log"
+          do
+            result="$(kubectl auth can-i ${check} -n annotation)"
+            echo "${check}: ${result}"
+            if [ "${result}" != "yes" ]; then
+              failed=1
+            fi
+          done
+
+          exit "${failed}"
 
   sync:
     if: github.event_name == 'workflow_dispatch'
@@ -72,9 +90,26 @@ jobs:
 
       - name: Check Kubernetes access
         run: |
-          test "$(kubectl auth can-i create jobs -n annotation)" = "yes"
-          test "$(kubectl auth can-i get jobs -n annotation)" = "yes"
-          test "$(kubectl auth can-i get pods/log -n annotation)" = "yes"
+          set -eu
+
+          failed=0
+          for check in \
+            "create jobs" \
+            "get jobs" \
+            "list jobs" \
+            "watch jobs" \
+            "get pods" \
+            "list pods" \
+            "get pods/log"
+          do
+            result="$(kubectl auth can-i ${check} -n annotation)"
+            echo "${check}: ${result}"
+            if [ "${result}" != "yes" ]; then
+              failed=1
+            fi
+          done
+
+          exit "${failed}"
 
       - name: Validate sync inputs
         run: |
@@ -165,7 +200,7 @@ jobs:
                       defaultMode: 0555
           EOF
 
-          kubectl apply -f /tmp/fiftyone-s3-sync-job.yaml
+          kubectl create -f /tmp/fiftyone-s3-sync-job.yaml
 
       - name: Wait for sync job
         if: inputs.wait_for_completion == 'true'

--- a/.github/workflows/fiftyone-s3-sync.yml
+++ b/.github/workflows/fiftyone-s3-sync.yml
@@ -2,6 +2,16 @@
 name: FiftyOne S3 dataset sync
 
 "on":
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - .github/workflows/fiftyone-s3-sync.yml
+      - apps/annotation/base/fiftyone/s3-sync.yaml
+      - apps/annotation/base/fiftyone/s3-secrets.yaml
+      - apps/annotation/base/kustomization.yaml
   workflow_dispatch:
     inputs:
       s3_prefix:
@@ -24,7 +34,29 @@ name: FiftyOne S3 dataset sync
           - "false"
 
 jobs:
+  preflight:
+    if: github.event_name == 'pull_request'
+    runs-on: on-prem-gh-runners
+
+    steps:
+      - name: Install kubectl if needed
+        run: |
+          if ! command -v kubectl >/dev/null 2>&1; then
+            curl -LO \
+              "https://dl.k8s.io/release/$(curl -L -s \
+              https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+            chmod +x kubectl
+            sudo mv kubectl /usr/local/bin/kubectl
+          fi
+
+      - name: Check Kubernetes access
+        run: |
+          test "$(kubectl auth can-i create jobs -n annotation)" = "yes"
+          test "$(kubectl auth can-i get jobs -n annotation)" = "yes"
+          test "$(kubectl auth can-i get pods/log -n annotation)" = "yes"
+
   sync:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: on-prem-gh-runners
 
     steps:

--- a/.github/workflows/fiftyone-s3-sync.yml
+++ b/.github/workflows/fiftyone-s3-sync.yml
@@ -2,17 +2,6 @@
 name: FiftyOne S3 dataset sync
 
 "on":
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-    paths:
-      - .github/workflows/fiftyone-s3-sync.yml
-      - apps/annotation/base/fiftyone/s3-sync.yaml
-      - apps/annotation/base/fiftyone/s3-sync-rbac.yaml
-      - apps/annotation/base/fiftyone/s3-secrets.yaml
-      - apps/annotation/base/kustomization.yaml
   workflow_dispatch:
     inputs:
       s3_prefix:
@@ -35,56 +24,7 @@ name: FiftyOne S3 dataset sync
           - "false"
 
 jobs:
-  preflight:
-    if: github.event_name == 'pull_request'
-    runs-on: on-prem-gh-runners
-
-    steps:
-      - name: Install kubectl if needed
-        run: |
-          if ! command -v kubectl >/dev/null 2>&1; then
-            curl -LO \
-              "https://dl.k8s.io/release/$(curl -L -s \
-              https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-            chmod +x kubectl
-            sudo mv kubectl /usr/local/bin/kubectl
-          fi
-
-      - name: Check Kubernetes access
-        run: |
-          set -eu
-
-          echo "Kubernetes context:"
-          kubectl config current-context || true
-
-          echo "Kubernetes identity:"
-          kubectl auth whoami || true
-
-          failed=0
-          for check in \
-            "create jobs" \
-            "get jobs" \
-            "list jobs" \
-            "watch jobs" \
-            "get pods" \
-            "list pods" \
-            "get pods --subresource=log"
-          do
-            set +e
-            output="$(kubectl auth can-i ${check} -n annotation 2>&1)"
-            status="$?"
-            set -e
-
-            echo "${check}: ${output}"
-            if [ "${status}" != "0" ] || [ "${output}" != "yes" ]; then
-              failed=1
-            fi
-          done
-
-          exit "${failed}"
-
   sync:
-    if: github.event_name == 'workflow_dispatch'
     runs-on: on-prem-gh-runners
 
     steps:

--- a/.github/workflows/fiftyone-s3-sync.yml
+++ b/.github/workflows/fiftyone-s3-sync.yml
@@ -54,6 +54,12 @@ jobs:
         run: |
           set -eu
 
+          echo "Kubernetes context:"
+          kubectl config current-context || true
+
+          echo "Kubernetes identity:"
+          kubectl auth whoami || true
+
           failed=0
           for check in \
             "create jobs" \
@@ -62,11 +68,15 @@ jobs:
             "watch jobs" \
             "get pods" \
             "list pods" \
-            "get pods/log"
+            "get pods --subresource=log"
           do
-            result="$(kubectl auth can-i ${check} -n annotation)"
-            echo "${check}: ${result}"
-            if [ "${result}" != "yes" ]; then
+            set +e
+            output="$(kubectl auth can-i ${check} -n annotation 2>&1)"
+            status="$?"
+            set -e
+
+            echo "${check}: ${output}"
+            if [ "${status}" != "0" ] || [ "${output}" != "yes" ]; then
               failed=1
             fi
           done
@@ -92,6 +102,12 @@ jobs:
         run: |
           set -eu
 
+          echo "Kubernetes context:"
+          kubectl config current-context || true
+
+          echo "Kubernetes identity:"
+          kubectl auth whoami || true
+
           failed=0
           for check in \
             "create jobs" \
@@ -100,11 +116,15 @@ jobs:
             "watch jobs" \
             "get pods" \
             "list pods" \
-            "get pods/log"
+            "get pods --subresource=log"
           do
-            result="$(kubectl auth can-i ${check} -n annotation)"
-            echo "${check}: ${result}"
-            if [ "${result}" != "yes" ]; then
+            set +e
+            output="$(kubectl auth can-i ${check} -n annotation 2>&1)"
+            status="$?"
+            set -e
+
+            echo "${check}: ${output}"
+            if [ "${status}" != "0" ] || [ "${output}" != "yes" ]; then
               failed=1
             fi
           done

--- a/.github/workflows/fiftyone-s3-sync.yml
+++ b/.github/workflows/fiftyone-s3-sync.yml
@@ -1,0 +1,148 @@
+---
+name: FiftyOne S3 dataset sync
+
+"on":
+  workflow_dispatch:
+    inputs:
+      s3_prefix:
+        description: S3 prefix under the mlflow bucket to sync
+        required: true
+        default: datasets
+        type: string
+      destination:
+        description: Destination path under the FiftyOne shared workspace
+        required: true
+        default: /datasets/s3-imports
+        type: string
+      wait_for_completion:
+        description: Wait for the sync job to complete and print logs
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+jobs:
+  sync:
+    runs-on: on-prem-gh-runners
+
+    steps:
+      - name: Install kubectl if needed
+        run: |
+          if ! command -v kubectl >/dev/null 2>&1; then
+            curl -LO \
+              "https://dl.k8s.io/release/$(curl -L -s \
+              https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+            chmod +x kubectl
+            sudo mv kubectl /usr/local/bin/kubectl
+          fi
+
+      - name: Check Kubernetes access
+        run: |
+          test "$(kubectl auth can-i create jobs -n annotation)" = "yes"
+          test "$(kubectl auth can-i get jobs -n annotation)" = "yes"
+          test "$(kubectl auth can-i get pods/log -n annotation)" = "yes"
+
+      - name: Validate sync inputs
+        run: |
+          JOB_NAME="fiftyone-s3-sync-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "JOB_NAME=${JOB_NAME}" >> "$GITHUB_ENV"
+
+          case "${{ inputs.s3_prefix }}" in
+            *[!A-Za-z0-9._/-]* | /* | *..*)
+              echo "Invalid S3 prefix: ${{ inputs.s3_prefix }}" >&2
+              exit 1
+              ;;
+          esac
+
+          case "${{ inputs.destination }}" in
+            /datasets/s3-imports | /datasets/s3-imports/*)
+              ;;
+            *)
+              echo "Destination must be under /datasets/s3-imports" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Trigger FiftyOne S3 sync
+        run: |
+          cat > /tmp/fiftyone-s3-sync-job.yaml <<EOF
+          ---
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: ${JOB_NAME}
+            namespace: annotation
+          spec:
+            backoffLimit: 1
+            ttlSecondsAfterFinished: 86400
+            activeDeadlineSeconds: 1800
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: type
+                              operator: In
+                              values:
+                                - app-worker
+                containers:
+                  - name: sync
+                    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+                    imagePullPolicy: IfNotPresent
+                    env:
+                      - name: S3_PREFIX
+                        value: "${{ inputs.s3_prefix }}"
+                      - name: DATASETS_DESTINATION
+                        value: "${{ inputs.destination }}"
+                    envFrom:
+                      - configMapRef:
+                          name: fiftyone-s3-sync-config
+                      - secretRef:
+                          name: fiftyone-s3-secrets
+                    command:
+                      - /scripts/sync-datasets.sh
+                    resources:
+                      requests:
+                        cpu: "100m"
+                        memory: "128Mi"
+                      limits:
+                        memory: "512Mi"
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: false
+                      capabilities:
+                        drop:
+                          - ALL
+                    volumeMounts:
+                      - name: datasets
+                        mountPath: /datasets
+                      - name: sync-script
+                        mountPath: /scripts
+                restartPolicy: Never
+                volumes:
+                  - name: datasets
+                    persistentVolumeClaim:
+                      claimName: labelstudio-shared-pvc
+                  - name: sync-script
+                    configMap:
+                      name: fiftyone-s3-sync-config
+                      defaultMode: 0555
+          EOF
+
+          kubectl apply -f /tmp/fiftyone-s3-sync-job.yaml
+
+      - name: Wait for sync job
+        if: inputs.wait_for_completion == 'true'
+        run: |
+          kubectl wait -n annotation \
+            --for=condition=complete \
+            "job/${JOB_NAME}" \
+            --timeout=30m
+
+      - name: Print sync logs
+        if: inputs.wait_for_completion == 'true'
+        run: kubectl logs -n annotation "job/${JOB_NAME}"

--- a/apps/annotation/base/fiftyone/README.md
+++ b/apps/annotation/base/fiftyone/README.md
@@ -82,6 +82,46 @@ S3-compatible storage such as MinIO or Ceph RGW should be treated as durable
 object storage. When datasets arrive there first, sync the selected prefix into
 the CephFS-backed `/datasets` workspace before importing it into FiftyOne.
 
+## S3 Sync
+
+The `fiftyone-s3-sync` CronJob mirrors datasets from the MLflow S3-compatible
+store into the shared `/datasets` workspace.
+
+Default source and destination:
+
+```text
+s3://mlflow/datasets -> /datasets/s3-imports
+```
+
+The CronJob is suspended by default. It does not run on a schedule. Use the
+manual GitHub Actions workflow `FiftyOne S3 dataset sync` to trigger a sync
+when a new dataset prefix is ready.
+
+The CronJob is guarded with `concurrencyPolicy: Forbid`, `backoffLimit: 1`,
+and a 30-minute deadline so failed or slow syncs do not overlap indefinitely.
+
+A cluster operator can also create a one-off Job from the CronJob template:
+
+```bash
+kubectl create job -n annotation --from=cronjob/fiftyone-s3-sync \
+  fiftyone-s3-sync-manual
+kubectl wait -n annotation --for=condition=complete \
+  job/fiftyone-s3-sync-manual --timeout=30m
+```
+
+The job uses `fiftyone-s3-secrets`, sourced from the same Vault path as the
+MLflow S3 configuration. Do not put S3 credentials in Git.
+
+Live sync checks:
+
+```bash
+kubectl get externalsecret fiftyone-s3-secrets -n annotation
+kubectl get secret fiftyone-s3-secrets -n annotation
+kubectl get cronjob fiftyone-s3-sync -n annotation
+kubectl logs job/fiftyone-s3-sync-manual -n annotation
+kubectl exec deploy/fiftyone -n annotation -- ls -la /datasets/s3-imports
+```
+
 ## User Workflow
 
 1. Add or sync a dataset into `/datasets`.

--- a/apps/annotation/base/fiftyone/README.md
+++ b/apps/annotation/base/fiftyone/README.md
@@ -77,11 +77,56 @@ mongodb://mongodb.mongodb.svc.cluster.local:27017/fiftyone
 ```
 
 Dataset media should be available to the FiftyOne pod through filesystem paths.
-For S3-compatible storage such as Ceph or MinIO, mount or sync the bucket into
-the pod before importing datasets.
+Open-source FiftyOne should be treated as filesystem-backed for media, so the
+active review workspace is exposed through CephFS rather than direct `s3://`
+paths.
 
-The pod also mounts the annotation shared PVC at `/ailab`, matching the shared
-workspace pattern used by Label Studio and the AI Lab shared work containers.
+The pod mounts the annotation shared CephFS PVC at:
+
+```text
+/datasets
+/ailab
+```
+
+`/datasets` is the preferred path to use in the FiftyOne IO plugin when loading
+seed image folders. `/ailab` is kept for compatibility with the shared
+annotation workspace pattern used by Label Studio and AI Lab shared work
+containers.
+
+Recommended workflow:
+
+```text
+1. Add a seed dataset to the shared workspace, or sync it there from S3/MinIO.
+2. Open FiftyOne.
+3. Use the IO plugin to import from /datasets.
+4. Review labels, boxes, tags, and saved views.
+5. Export curated labels/manifests back to the shared workspace.
+6. Sync curated outputs to S3/MLflow artifacts when needed.
+```
+
+Class-folder example:
+
+```text
+/datasets/incoming/2026-06-05/batch-001/
+  Ambrosia artemisiifolia/
+    image001.jpg
+  Avena fatua/
+    image002.jpg
+```
+
+COCO example:
+
+```text
+/datasets/coco/2026-06-05/batch-001/
+  data/
+    image001.jpg
+  labels.json
+```
+
+S3-compatible storage such as MinIO/Ceph RGW should be treated as durable
+object/artifact storage. If a dataset lands in S3 first, sync the selected
+prefix into the CephFS-backed `/datasets` workspace before importing it into
+FiftyOne.
 
 ## Validation
 
@@ -93,6 +138,7 @@ kubectl logs deploy/fiftyone -n annotation
 kubectl logs statefulset/mongodb -n mongodb
 kubectl rollout restart deploy/fiftyone -n annotation
 kubectl port-forward svc/fiftyone 5151:5151 -n annotation
+kubectl exec deploy/fiftyone -n annotation -- ls /datasets
 ```
 
 Plugin checks:
@@ -147,3 +193,118 @@ Manual checks:
 - Confirm dataset metadata remains available after restart.
 - Restart the MongoDB pod and confirm metadata persists from the StatefulSet
   volume claim.
+
+Shared dataset workspace validation:
+
+1. Confirm the shared workspace is mounted:
+
+   ```bash
+   kubectl exec deploy/fiftyone -n annotation -- ls -la /datasets
+   ```
+
+2. Create a tiny class-folder smoke dataset from the FiftyOne pod terminal:
+
+   ```bash
+   kubectl exec deploy/fiftyone -n annotation -- python - <<'PY'
+   from pathlib import Path
+   from PIL import Image, ImageDraw
+
+   root = Path("/datasets/fiftyone-smoke/class-folders")
+   species = root / "Ambrosia artemisiifolia"
+   species.mkdir(parents=True, exist_ok=True)
+
+   image = Image.new("RGB", (320, 240), "#202428")
+   draw = ImageDraw.Draw(image)
+   draw.ellipse((80, 70, 240, 170), fill="#b99b55", outline="#f6e6a8", width=6)
+   image.save(species / "seed-001.jpg")
+   PY
+   ```
+
+3. Import the class-folder dataset:
+
+   ```bash
+   kubectl exec deploy/fiftyone -n annotation -- python - <<'PY'
+   import fiftyone as fo
+
+   name = "fiftyone-shared-storage-class-smoke"
+   if fo.dataset_exists(name):
+       fo.delete_dataset(name)
+
+   dataset = fo.Dataset.from_dir(
+       dataset_dir="/datasets/fiftyone-smoke/class-folders",
+       dataset_type=fo.types.ImageClassificationDirectoryTree,
+       name=name,
+   )
+   dataset.persistent = True
+   print(dataset.name, len(dataset), dataset.distinct("ground_truth.label"))
+   PY
+   ```
+
+4. Create and import a tiny COCO smoke dataset:
+
+   ```bash
+   kubectl exec deploy/fiftyone -n annotation -- python - <<'PY'
+   import json
+   from pathlib import Path
+   from PIL import Image, ImageDraw
+   import fiftyone as fo
+
+   root = Path("/datasets/fiftyone-smoke/coco")
+   data = root / "data"
+   data.mkdir(parents=True, exist_ok=True)
+
+   image = Image.new("RGB", (320, 240), "#202428")
+   draw = ImageDraw.Draw(image)
+   draw.ellipse((80, 70, 240, 170), fill="#b99b55", outline="#f6e6a8", width=6)
+   image.save(data / "seed-001.jpg")
+
+   labels = {
+       "images": [
+           {"id": 1, "file_name": "seed-001.jpg", "width": 320, "height": 240}
+       ],
+       "annotations": [
+           {
+               "id": 1,
+               "image_id": 1,
+               "category_id": 1,
+               "bbox": [80, 70, 160, 100],
+               "area": 16000,
+               "iscrowd": 0,
+           }
+       ],
+       "categories": [{"id": 1, "name": "Ambrosia artemisiifolia"}],
+   }
+   (root / "labels.json").write_text(json.dumps(labels), encoding="utf-8")
+
+   name = "fiftyone-shared-storage-coco-smoke"
+   if fo.dataset_exists(name):
+       fo.delete_dataset(name)
+
+   dataset = fo.Dataset.from_dir(
+       dataset_type=fo.types.COCODetectionDataset,
+       data_path=str(data),
+       labels_path=str(root / "labels.json"),
+       label_field="ground_truth",
+       name=name,
+   )
+   dataset.persistent = True
+   print(dataset.name, len(dataset), dataset.count("ground_truth.detections"))
+   PY
+   ```
+
+5. Restart FiftyOne and confirm both datasets still exist:
+
+   ```bash
+   kubectl rollout restart deploy/fiftyone -n annotation
+   kubectl rollout status deploy/fiftyone -n annotation
+   kubectl exec deploy/fiftyone -n annotation -- python - <<'PY'
+   import fiftyone as fo
+
+   for name in (
+       "fiftyone-shared-storage-class-smoke",
+       "fiftyone-shared-storage-coco-smoke",
+   ):
+       dataset = fo.load_dataset(name)
+       print(name, len(dataset), dataset.persistent)
+   PY
+   ```

--- a/apps/annotation/base/fiftyone/README.md
+++ b/apps/annotation/base/fiftyone/README.md
@@ -100,6 +100,10 @@ when a new dataset prefix is ready.
 The CronJob is guarded with `concurrencyPolicy: Forbid`, `backoffLimit: 1`,
 and a 30-minute deadline so failed or slow syncs do not overlap indefinitely.
 
+The workflow also runs a pull request preflight check that verifies the
+on-prem runner has permission to create Jobs and read Job logs in the
+`annotation` namespace.
+
 A cluster operator can also create a one-off Job from the CronJob template:
 
 ```bash

--- a/apps/annotation/base/fiftyone/README.md
+++ b/apps/annotation/base/fiftyone/README.md
@@ -1,31 +1,29 @@
 # FiftyOne
 
-This directory deploys FiftyOne as an internal ML dataset curation and visual
-review workbench.
+FiftyOne is deployed as an internal dataset curation and visual review
+workbench for AI Lab image datasets.
 
-## Scope
+## Runtime
 
-- The FiftyOne app runs as a single-replica Deployment.
-- The deployed image extends the pinned upstream FiftyOne image and installs
-  the AI Lab's required FiftyOne plugins.
-- MongoDB is deployed as a shared storage service from `storage/mongodb` and
-  stores FiftyOne metadata.
-- This first pass intentionally skips MongoDB backups, clustering, and
-  hardening so the team can validate the app, database connection, and
-  persistence.
-- Access control is limited to the existing cluster/network controls for this
-  first pass.
+- The app runs as a single-replica Deployment.
+- Metadata is stored in the shared MongoDB service:
+
+  ```text
+  mongodb://mongodb.mongodb.svc.cluster.local:27017/fiftyone
+  ```
+
+- The image is built in `ai-cfia/devops` under `dockerfiles/fiftyone`.
+- The deployment consumes the published image from GHCR.
 
 ## Plugins
 
-The custom FiftyOne image is built from:
+The custom image extends:
 
 ```text
 voxel51/fiftyone:1.15.0-python3.9-20260502
 ```
 
-and installs the following plugins from the pinned `voxel51/fiftyone-plugins`
-ref in the DevOps Dockerfile:
+Installed plugins:
 
 ```text
 @voxel51/annotation
@@ -34,120 +32,83 @@ ref in the DevOps Dockerfile:
 @voxel51/utils
 ```
 
-Delegation is intentionally not installed for this phase.
+`@voxel51/delegation` is intentionally not installed.
 
-Built-in vs installed behavior:
-
-- `@voxel51/operators` and `@voxel51/panels` are already built into the
-  upstream FiftyOne image.
-- `@voxel51/annotation`, `@voxel51/io`, `@voxel51/brain`, and
-  `@voxel51/utils` are installed into `/opt/fiftyone/plugins` by the custom
-  image build.
-- `FIFTYONE_PLUGINS_DIR` is set to `/opt/fiftyone/plugins` in the deployment so
-  FiftyOne loads the installed plugins from the image.
-
-The image also installs CPU-only `torch`, `torchvision`, and `umap-learn`. The
-Brain plugin can use precomputed embeddings without Torch, but the UI's
-model-based similarity workflow loads FiftyOne Model Zoo models such as
-`resnet18-imagenet-torch`, which require Torch at runtime. The Brain
-visualization workflow uses UMAP by default, which requires `umap-learn`.
-
-The image build is owned by the `ai-cfia/devops` repository under
-`dockerfiles/fiftyone`. This deployment only consumes the published image.
+The image also includes CPU-only `torch`, `torchvision`, and `umap-learn` for
+the Brain similarity and visualization workflows.
 
 ## Networking
 
-FiftyOne uses the same shared Gateway pattern as Label Studio. The HTTPRoute
-exposes:
+FiftyOne is exposed through the shared Louis Gateway:
 
 ```text
 https://fiftyone.inspection.alpha.canada.ca
 ```
 
-The Gateway listener is defined in `apps/louis/base/gateway.yaml`, and the
-HTTPRoute is defined in `apps/annotation/base/httproute.yaml`. DNS should point
-to the shared Gateway IP.
+The HTTPRoute is defined in `apps/annotation/base/httproute.yaml`. The Gateway
+listener is defined in `apps/louis/base/gateway.yaml`.
 
-## Storage
+## Dataset Storage
 
-FiftyOne metadata is stored in the shared MongoDB service:
-
-```text
-mongodb://mongodb.mongodb.svc.cluster.local:27017/fiftyone
-```
-
-Dataset media should be available to the FiftyOne pod through filesystem paths.
-Open-source FiftyOne should be treated as filesystem-backed for media, so the
-active review workspace is exposed through CephFS rather than direct `s3://`
-paths.
-
-The pod mounts the annotation shared CephFS PVC at:
+FiftyOne should load media from filesystem paths visible inside the pod. The
+shared annotation CephFS workspace is mounted at:
 
 ```text
 /datasets
 /ailab
 ```
 
-`/datasets` is the preferred path to use in the FiftyOne IO plugin when loading
-seed image folders. `/ailab` is kept for compatibility with the shared
-annotation workspace pattern used by Label Studio and AI Lab shared work
-containers.
+Use `/datasets` for new FiftyOne imports. `/ailab` is kept for compatibility
+with the existing shared annotation workspace.
 
-Recommended workflow:
+Recommended dataset layouts:
 
 ```text
-1. Add a seed dataset to the shared workspace, or sync it there from S3/MinIO.
-2. Open FiftyOne.
-3. Use the IO plugin to import from /datasets.
-4. Review labels, boxes, tags, and saved views.
-5. Export curated labels/manifests back to the shared workspace.
-6. Sync curated outputs to S3/MLflow artifacts when needed.
-```
-
-Class-folder example:
-
-```text
-/datasets/incoming/2026-06-05/batch-001/
+/datasets/incoming/<date>/<batch>/
   Ambrosia artemisiifolia/
     image001.jpg
   Avena fatua/
     image002.jpg
 ```
 
-COCO example:
-
 ```text
-/datasets/coco/2026-06-05/batch-001/
+/datasets/coco/<date>/<batch>/
   data/
     image001.jpg
   labels.json
 ```
 
-S3-compatible storage such as MinIO/Ceph RGW should be treated as durable
-object/artifact storage. If a dataset lands in S3 first, sync the selected
-prefix into the CephFS-backed `/datasets` workspace before importing it into
-FiftyOne.
+S3-compatible storage such as MinIO or Ceph RGW should be treated as durable
+object storage. When datasets arrive there first, sync the selected prefix into
+the CephFS-backed `/datasets` workspace before importing it into FiftyOne.
+
+## User Workflow
+
+1. Add or sync a dataset into `/datasets`.
+2. Open FiftyOne.
+3. Use the IO plugin to import the dataset from `/datasets`.
+4. Review images, labels, boxes, tags, and saved views.
+5. Export curated labels or manifests back to the shared workspace.
+6. Sync curated outputs to S3 or MLflow artifacts when needed.
 
 ## Validation
 
+Basic deployment checks:
+
 ```bash
-kubectl get httproute -n annotation
 kubectl get pods,svc,pvc -n annotation
-kubectl get pods,svc,statefulset,pvc -n mongodb
+kubectl get httproute -n annotation
 kubectl logs deploy/fiftyone -n annotation
-kubectl logs statefulset/mongodb -n mongodb
-kubectl rollout restart deploy/fiftyone -n annotation
-kubectl port-forward svc/fiftyone 5151:5151 -n annotation
-kubectl exec deploy/fiftyone -n annotation -- ls /datasets
+kubectl exec deploy/fiftyone -n annotation -- ls -la /datasets
 ```
 
-Plugin checks:
+Plugin check:
 
 ```bash
 kubectl exec deploy/fiftyone -n annotation -- fiftyone plugins list
 ```
 
-Expected installed plugins:
+Expected plugins:
 
 ```text
 @voxel51/annotation
@@ -156,165 +117,25 @@ Expected installed plugins:
 @voxel51/utils
 ```
 
-Expected excluded plugin:
+Persistence check:
 
-```text
-@voxel51/delegation
+```bash
+kubectl rollout restart deploy/fiftyone -n annotation
+kubectl rollout status deploy/fiftyone -n annotation
 ```
 
-should not be listed.
+After restart, confirm previously imported datasets are still listed in the
+FiftyOne UI.
 
-Local validation of the custom image:
+## Smoke Test
 
-- Docker image built successfully.
-- `fiftyone plugins list` showed all four requested plugins enabled.
-- CPU-only `torch` and `torchvision` imported successfully.
-- `umap-learn` imported successfully.
-- Brain model-based similarity ran successfully with
-  `resnet18-imagenet-torch` on a local smoke-test dataset.
-- Brain visualization ran successfully with precomputed embeddings on a local
-  smoke-test dataset.
-- A local FiftyOne container started successfully against MongoDB and returned
-  HTTP 200.
-- Brain duplicate/similarity workflows were previously validated in the local
-  validation lab on a sample seed dataset:
-  - exact duplicates: pass
-  - similarity: pass
-  - visualization: pass
-  - uniqueness: pass
-  - COCO similarity: pass
+Use a small class-folder or COCO dataset under `/datasets` to validate imports.
 
-Manual checks:
+Class-folder import should preserve species names from folder names.
+COCO import should render bounding boxes in the sample viewer.
 
-- Open `https://fiftyone.inspection.alpha.canada.ca`.
-- Confirm the UI loads.
-- Import or attach a small test dataset if appropriate.
-- Restart the FiftyOne pod.
-- Confirm dataset metadata remains available after restart.
-- Restart the MongoDB pod and confirm metadata persists from the StatefulSet
-  volume claim.
+For a repeatable local version of this validation, use:
 
-Shared dataset workspace validation:
-
-1. Confirm the shared workspace is mounted:
-
-   ```bash
-   kubectl exec deploy/fiftyone -n annotation -- ls -la /datasets
-   ```
-
-2. Create a tiny class-folder smoke dataset from the FiftyOne pod terminal:
-
-   ```bash
-   kubectl exec deploy/fiftyone -n annotation -- python - <<'PY'
-   from pathlib import Path
-   from PIL import Image, ImageDraw
-
-   root = Path("/datasets/fiftyone-smoke/class-folders")
-   species = root / "Ambrosia artemisiifolia"
-   species.mkdir(parents=True, exist_ok=True)
-
-   image = Image.new("RGB", (320, 240), "#202428")
-   draw = ImageDraw.Draw(image)
-   draw.ellipse((80, 70, 240, 170), fill="#b99b55", outline="#f6e6a8", width=6)
-   image.save(species / "seed-001.jpg")
-   PY
-   ```
-
-3. Import the class-folder dataset:
-
-   ```bash
-   kubectl exec deploy/fiftyone -n annotation -- python - <<'PY'
-   import fiftyone as fo
-
-   name = "fiftyone-shared-storage-class-smoke"
-   if fo.dataset_exists(name):
-       fo.delete_dataset(name)
-
-   dataset = fo.Dataset.from_dir(
-       dataset_dir="/datasets/fiftyone-smoke/class-folders",
-       dataset_type=fo.types.ImageClassificationDirectoryTree,
-       name=name,
-   )
-   dataset.persistent = True
-   print(dataset.name, len(dataset), dataset.distinct("ground_truth.label"))
-   PY
-   ```
-
-4. Create and import a tiny COCO smoke dataset:
-
-   ```bash
-   kubectl exec deploy/fiftyone -n annotation -- python - <<'PY'
-   import json
-   from pathlib import Path
-   from PIL import Image, ImageDraw
-   import fiftyone as fo
-
-   root = Path("/datasets/fiftyone-smoke/coco")
-   data = root / "data"
-   data.mkdir(parents=True, exist_ok=True)
-
-   image = Image.new("RGB", (320, 240), "#202428")
-   draw = ImageDraw.Draw(image)
-   draw.ellipse((80, 70, 240, 170), fill="#b99b55", outline="#f6e6a8", width=6)
-   image.save(data / "seed-001.jpg")
-
-   labels = {
-       "images": [
-           {"id": 1, "file_name": "seed-001.jpg", "width": 320, "height": 240}
-       ],
-       "annotations": [
-           {
-               "id": 1,
-               "image_id": 1,
-               "category_id": 1,
-               "bbox": [80, 70, 160, 100],
-               "area": 16000,
-               "iscrowd": 0,
-           }
-       ],
-       "categories": [{"id": 1, "name": "Ambrosia artemisiifolia"}],
-   }
-   (root / "labels.json").write_text(json.dumps(labels), encoding="utf-8")
-
-   name = "fiftyone-shared-storage-coco-smoke"
-   if fo.dataset_exists(name):
-       fo.delete_dataset(name)
-
-   dataset = fo.Dataset.from_dir(
-       dataset_type=fo.types.COCODetectionDataset,
-       data_path=str(data),
-       labels_path=str(root / "labels.json"),
-       name=name,
-   )
-   dataset.persistent = True
-
-   detections_field = next(
-       name
-       for name, field in dataset.get_field_schema().items()
-       if getattr(field, "document_type", None) is fo.Detections
-   )
-   print(
-       dataset.name,
-       len(dataset),
-       detections_field,
-       dataset.count(f"{detections_field}.detections"),
-   )
-   PY
-   ```
-
-5. Restart FiftyOne and confirm both datasets still exist:
-
-   ```bash
-   kubectl rollout restart deploy/fiftyone -n annotation
-   kubectl rollout status deploy/fiftyone -n annotation
-   kubectl exec deploy/fiftyone -n annotation -- python - <<'PY'
-   import fiftyone as fo
-
-   for name in (
-       "fiftyone-shared-storage-class-smoke",
-       "fiftyone-shared-storage-coco-smoke",
-   ):
-       dataset = fo.load_dataset(name)
-       print(name, len(dataset), dataset.persistent)
-   PY
-   ```
+```text
+/Users/youssefjedidi/CFIA/fiftyone-validation-lab
+```

--- a/apps/annotation/base/fiftyone/README.md
+++ b/apps/annotation/base/fiftyone/README.md
@@ -284,11 +284,21 @@ Shared dataset workspace validation:
        dataset_type=fo.types.COCODetectionDataset,
        data_path=str(data),
        labels_path=str(root / "labels.json"),
-       label_field="ground_truth",
        name=name,
    )
    dataset.persistent = True
-   print(dataset.name, len(dataset), dataset.count("ground_truth.detections"))
+
+   detections_field = next(
+       name
+       for name, field in dataset.get_field_schema().items()
+       if getattr(field, "document_type", None) is fo.Detections
+   )
+   print(
+       dataset.name,
+       len(dataset),
+       detections_field,
+       dataset.count(f"{detections_field}.detections"),
+   )
    PY
    ```
 

--- a/apps/annotation/base/fiftyone/fiftyone.yaml
+++ b/apps/annotation/base/fiftyone/fiftyone.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: fiftyone
@@ -59,6 +61,8 @@ spec:
               mountPath: /fiftyone
             - name: shared-data
               mountPath: /ailab
+            - name: shared-data
+              mountPath: /datasets
           startupProbe:
             httpGet:
               path: /

--- a/apps/annotation/base/fiftyone/s3-secrets.yaml
+++ b/apps/annotation/base/fiftyone/s3-secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fiftyone-s3-secrets
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: fiftyone-s3-secrets
+  dataFrom:
+    - extract:
+        key: secrets/mlflow/s3

--- a/apps/annotation/base/fiftyone/s3-sync-rbac.yaml
+++ b/apps/annotation/base/fiftyone/s3-sync-rbac.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fiftyone-s3-sync-runner
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fiftyone-s3-sync-runner
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: on-prem-gh-runners
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fiftyone-s3-sync-runner

--- a/apps/annotation/base/fiftyone/s3-sync-rbac.yaml
+++ b/apps/annotation/base/fiftyone/s3-sync-rbac.yaml
@@ -34,7 +34,7 @@ metadata:
   name: fiftyone-s3-sync-runner
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: on-prem-gh-runners-gha-rs-no-permission
     namespace: on-prem-gh-runners
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/apps/annotation/base/fiftyone/s3-sync.yaml
+++ b/apps/annotation/base/fiftyone/s3-sync.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fiftyone-s3-sync-config
+data:
+  S3_BUCKET: mlflow
+  S3_PREFIX: datasets
+  DATASETS_DESTINATION: /datasets/s3-imports
+  sync-datasets.sh: |
+    #!/bin/sh
+    set -eu
+
+    : "${MLFLOW_S3_ENDPOINT_URL:?missing endpoint URL}"
+    : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required}"
+    : "${AWS_SECRET_ACCESS_KEY:?missing secret access key}"
+    : "${S3_BUCKET:?S3_BUCKET is required}"
+    : "${S3_PREFIX:?S3_PREFIX is required}"
+    : "${DATASETS_DESTINATION:?DATASETS_DESTINATION is required}"
+
+    mkdir -p "${DATASETS_DESTINATION}"
+    mc alias set mlflow "${MLFLOW_S3_ENDPOINT_URL}" \
+      "${AWS_ACCESS_KEY_ID}" "${AWS_SECRET_ACCESS_KEY}"
+    mc mirror --overwrite \
+      "mlflow/${S3_BUCKET}/${S3_PREFIX}" \
+      "${DATASETS_DESTINATION}"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: fiftyone-s3-sync
+spec:
+  # Reusable sync template. It is intentionally suspended so dataset syncs are
+  # triggered explicitly, for example by the manual GitHub Actions workflow.
+  schedule: "0 6 * * *"
+  suspend: true
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 86400
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: type
+                        operator: In
+                        values:
+                          - app-worker
+          containers:
+            - name: sync
+              image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+              imagePullPolicy: IfNotPresent
+              envFrom:
+                - configMapRef:
+                    name: fiftyone-s3-sync-config
+                - secretRef:
+                    name: fiftyone-s3-secrets
+              command:
+                - /scripts/sync-datasets.sh
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "128Mi"
+                limits:
+                  memory: "512Mi"
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: datasets
+                  mountPath: /datasets
+                - name: sync-script
+                  mountPath: /scripts
+          restartPolicy: Never
+          volumes:
+            - name: datasets
+              persistentVolumeClaim:
+                claimName: labelstudio-shared-pvc
+            - name: sync-script
+              configMap:
+                name: fiftyone-s3-sync-config
+                defaultMode: 0555

--- a/apps/annotation/base/kustomization.yaml
+++ b/apps/annotation/base/kustomization.yaml
@@ -8,4 +8,6 @@ resources:
   - labelstudio/labelstudio.yaml
   - labelstudio/certificates.yaml
   - fiftyone/fiftyone.yaml
+  - fiftyone/s3-secrets.yaml
+  - fiftyone/s3-sync.yaml
   - httproute.yaml

--- a/apps/annotation/base/kustomization.yaml
+++ b/apps/annotation/base/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - labelstudio/certificates.yaml
   - fiftyone/fiftyone.yaml
   - fiftyone/s3-secrets.yaml
+  - fiftyone/s3-sync-rbac.yaml
   - fiftyone/s3-sync.yaml
   - httproute.yaml


### PR DESCRIPTION
Closes #441
## Summary

Adds a workflow for syncing seed datasets from the shared S3-compatible storage into the FiftyOne dataset workspace.

Datasets are synced into:

```text
/datasets/s3-imports
```

and can then be imported from the FiftyOne UI.

## Changes

- Add S3 credentials wiring for FiftyOne sync jobs using the existing MLflow S3 Vault path.
- Add a suspended `fiftyone-s3-sync` CronJob as the reusable sync template.
- Add a manual GitHub Actions workflow to run a one-off sync job.
- Document the expected sync and import workflow.

## Validation

- Ran YAML linting.
- Ran `kubectl kustomize apps/annotation/base`.
- Locally tested the S3-compatible sync flow with MinIO.
- Locally tested class-folder and COCO imports in FiftyOne.
- Confirmed local pod restart/persistence behavior.

## Notes

The sync workflow is manual for now to avoid recurring S3 scans. After deploy, we still need to confirm the on-prem runner can create Jobs in the `annotation` namespace.