### PR TITLE
feat: mount FiftyOne datasets with CephFS PVC

### DIFF
--- a/apps/annotation/base/fiftyone/README.md
+++ b/apps/annotation/base/fiftyone/README.md
@@ -77,11 +77,43 @@ mongodb://mongodb.mongodb.svc.cluster.local:27017/fiftyone
 ```
 
 Dataset media should be available to the FiftyOne pod through filesystem paths.
-For S3-compatible storage such as Ceph or MinIO, mount or sync the bucket into
-the pod before importing datasets.
+
+The deployment mounts a dedicated CephFS shared filesystem PVC for datasets:
+
+```text
+/datasets
+```
+
+The dataset PVC uses the `ceph-cold-filesystem` storage class with
+`ReadWriteMany`, matching the existing Rook/CephFS shared filesystem pattern in
+Howard. This keeps the first storage pass simple: files are made available on a
+normal filesystem path, and FiftyOne imports them from there.
 
 The pod also mounts the annotation shared PVC at `/ailab`, matching the shared
 workspace pattern used by Label Studio and the AI Lab shared work containers.
+
+Recommended import paths:
+
+```text
+/datasets
+/ailab
+```
+
+For seed class-folder datasets, keep species names in folder names:
+
+```text
+/datasets/Ambrosia artemisiifolia/
+  image001.jpg
+```
+
+For COCO detection datasets:
+
+```text
+/datasets/<batch>/
+  data/
+    image001.jpg
+  labels.json
+```
 
 ## Validation
 
@@ -90,6 +122,7 @@ kubectl get httproute -n annotation
 kubectl get pods,svc,pvc -n annotation
 kubectl get pods,svc,statefulset,pvc -n mongodb
 kubectl logs deploy/fiftyone -n annotation
+kubectl exec deploy/fiftyone -n annotation -- ls -la /datasets
 kubectl logs statefulset/mongodb -n mongodb
 kubectl rollout restart deploy/fiftyone -n annotation
 kubectl port-forward svc/fiftyone 5151:5151 -n annotation

--- a/apps/annotation/base/fiftyone/fiftyone.yaml
+++ b/apps/annotation/base/fiftyone/fiftyone.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: fiftyone
@@ -59,6 +61,8 @@ spec:
               mountPath: /fiftyone
             - name: shared-data
               mountPath: /ailab
+            - name: datasets
+              mountPath: /datasets
           startupProbe:
             httpGet:
               path: /
@@ -90,6 +94,9 @@ spec:
         - name: shared-data
           persistentVolumeClaim:
             claimName: labelstudio-shared-pvc
+        - name: datasets
+          persistentVolumeClaim:
+            claimName: fiftyone-datasets-pvc
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -105,6 +112,22 @@ spec:
   resources:
     requests:
       storage: 20Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fiftyone-datasets-pvc
+  labels:
+    app.kubernetes.io/name: fiftyone
+    app.kubernetes.io/part-of: fiftyone
+spec:
+  storageClassName: ceph-cold-filesystem
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 4Ti
+  volumeMode: Filesystem
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

Mounts a dedicated CephFS-backed dataset volume into the FiftyOne pod at `/datasets` so FiftyOne can import class-folder and COCO datasets from a normal filesystem path.

## Changes

- Adds a new `fiftyone-datasets-pvc`
- Uses `ceph-cold-filesystem`
- Uses `ReadWriteMany`
- Mounts the dataset PVC at `/datasets`
- Keeps the existing `/ailab` shared workspace mount
- Uses `Recreate` for the single-replica FiftyOne deployment
- Updates the FiftyOne README with the dataset import path and validation steps

## Validation

- `yamllint apps/annotation/base/fiftyone/fiftyone.yaml apps/annotation/base/kustomization.yaml`
- `kubectl kustomize apps/annotation/base`
- `git diff --check`

Relates to #441