### PR TITLE
feat: add FiftyOne shared dataset PVC in ailab-shared

### DIFF
--- a/apps/ailab-shared/base/sharedpvc.yaml
+++ b/apps/ailab-shared/base/sharedpvc.yaml
@@ -11,7 +11,21 @@ spec:
       storage: 14Ti
   storageClassName: ceph-cold-filesystem
   volumeMode: Filesystem
-
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fiftyone-datasets-pvc
+  namespace: ailab-shared
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 4Ti
+  volumeName: pvc-4ff93e0d-e7b3-406c-b3ed-8e50142c0c3d-ailab-shared
+  storageClassName: ceph-cold-filesystem
+  volumeMode: Filesystem
 # ---
 # kind: PersistentVolumeClaim
 # apiVersion: v1

--- a/apps/ailab-shared/base/yjdev.yaml
+++ b/apps/ailab-shared/base/yjdev.yaml
@@ -43,6 +43,8 @@ spec:
               mountPath: /dev/shm
             - name: yjdev-volume
               mountPath: /yjdev
+            - name: fiftyone-datasets-volume
+              mountPath: /datasets
           securityContext:
             # runAsUser: 1000
             # runAsGroup: 1000
@@ -65,6 +67,9 @@ spec:
         - name: yjdev-volume
           persistentVolumeClaim:
             claimName: yjdev-pvc
+        - name: fiftyone-datasets-volume
+          persistentVolumeClaim:
+            claimName: fiftyone-datasets-pvc
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

Adds the shared FiftyOne dataset PVC in `apps/ailab-shared/base/sharedpvc.yaml` and mounts it into `yjdev` at `/datasets` for validation from `ailab-shared`.

## Checks

- `kubectl kustomize apps/ailab-shared/base`
- `yamllint apps/ailab-shared/base/sharedpvc.yaml`

## Note

The live static PV was applied separately on `ailab6`. This PR adds the repo-managed consumer PVC and attaches it to `yjdev` so we can verify the shared CephFS volume from the dev container.