### PR TITLE
Enable FiftyOne S3 dataset mount

### DIFF
--- a/apps/annotation/base/fiftyone/fiftyone.yaml
+++ b/apps/annotation/base/fiftyone/fiftyone.yaml
@@ -139,6 +139,7 @@ spec:
                 "${FIFTYONE_S3_MOUNT_PATH}" \
                 --read-only \
                 --allow-other \
+                --allow-non-empty \
                 --dir-cache-time 1m \
                 --poll-interval 0 \
                 --log-level INFO &

--- a/apps/annotation/base/fiftyone/fiftyone.yaml
+++ b/apps/annotation/base/fiftyone/fiftyone.yaml
@@ -36,18 +36,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
-            - -c
-            - |
-              set -eu
-              echo "Waiting for S3 dataset mount..."
-              for _ in $(seq 1 90); do
-                if [ -f /s3-mount-status/ready ]; then
-                  exec python -m fiftyone.server.main --port 5151
-                fi
-                sleep 2
-              done
-              echo "Timed out waiting for S3 dataset mount" >&2
-              exit 1
+            - /opt/fiftyone-startup/wait-for-s3-mount.sh
           env:
             - name: FIFTYONE_DATABASE_URI
               value: mongodb://mongodb.mongodb.svc.cluster.local:27017/fiftyone
@@ -61,6 +50,8 @@ spec:
               value: /fiftyone/zoo/models
             - name: FIFTYONE_PLUGINS_DIR
               value: /opt/fiftyone/plugins
+            - name: FIFTYONE_S3_MOUNT_PATH
+              value: /fiftyone-s3
           ports:
             - containerPort: 5151
               name: http
@@ -76,6 +67,9 @@ spec:
               mountPropagation: HostToContainer
             - name: s3-mount-status
               mountPath: /s3-mount-status
+              readOnly: true
+            - name: startup-scripts
+              mountPath: /opt/fiftyone-startup
               readOnly: true
           startupProbe:
             httpGet:
@@ -107,72 +101,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
-            - -c
-            - |
-              set -eu
-
-              : "${MLFLOW_S3_ENDPOINT_URL:?missing S3 endpoint URL}"
-              : "${AWS_ACCESS_KEY_ID:?missing AWS access key ID}"
-              : "${AWS_SECRET_ACCESS_KEY:?missing AWS secret access key}"
-              : "${FIFTYONE_S3_BUCKET:?missing S3 bucket}"
-              : "${FIFTYONE_S3_PREFIX:?missing S3 prefix}"
-
-              # Remove any stale readiness flags from previous runs
-              rm -f /s3-mount-status/ready
-
-              mkdir -p "${FIFTYONE_S3_MOUNT_PATH}"
-
-              credentials_file=/root/.passwd-s3fs
-              printf '%s:%s\n' \
-                "${AWS_ACCESS_KEY_ID}" \
-                "${AWS_SECRET_ACCESS_KEY}" > "${credentials_file}"
-              chmod 600 "${credentials_file}"
-
-              # Ensure the FUSE allow_other option is configured idempotently.
-              touch /etc/fuse.conf
-              if ! grep -q '^user_allow_other' /etc/fuse.conf; then
-                echo 'user_allow_other' >> /etc/fuse.conf
-              fi
-
-              # Follow the FiftyOne cloud-storage guide: mount S3 as a local
-              # read-only filesystem, then let FiftyOne import from that path.
-              s3fs \
-                "${FIFTYONE_S3_BUCKET}:/${FIFTYONE_S3_PREFIX}" \
-                "${FIFTYONE_S3_MOUNT_PATH}" \
-                -f \
-                -o passwd_file="${credentials_file}" \
-                -o url="${MLFLOW_S3_ENDPOINT_URL}" \
-                -o use_path_request_style \
-                -o allow_other \
-                -o ro \
-                -o nonempty \
-                -o compat_dir \
-                -o umask=0022 \
-                -o stat_cache_expire=60 \
-                -o dbglevel=info &
-
-              mount_pid="$!"
-
-              # Clean up the readiness flag, password file, and s3fs process.
-              trap 'rm -f /s3-mount-status/ready "${credentials_file}";
-                kill "${mount_pid}" 2>/dev/null || true' EXIT TERM INT
-
-              # Verify the mount point is active and listable before startup.
-              for _ in $(seq 1 60); do
-                if grep -Fq " ${FIFTYONE_S3_MOUNT_PATH} " /proc/mounts &&
-                  ls "${FIFTYONE_S3_MOUNT_PATH}" >/dev/null 2>&1; then
-                  touch /s3-mount-status/ready
-                  wait "${mount_pid}"
-                fi
-                if ! kill -0 "${mount_pid}" 2>/dev/null; then
-                  wait "${mount_pid}"
-                fi
-                sleep 2
-              done
-
-              echo "S3 dataset mount did not become ready" >&2
-              kill "${mount_pid}" 2>/dev/null || true
-              exit 1
+            - /opt/fiftyone-startup/mount-s3-datasets.sh
           env:
             - name: FIFTYONE_S3_BUCKET
               value: mlflow
@@ -180,6 +109,8 @@ spec:
               value: datasets
             - name: FIFTYONE_S3_MOUNT_PATH
               value: /fiftyone-s3
+            - name: FIFTYONE_S3_REGION
+              value: us-east-1
           envFrom:
             - secretRef:
                 name: fiftyone-s3-secrets
@@ -189,6 +120,18 @@ spec:
               memory: "128Mi"
             limits:
               memory: "512Mi"
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  test -f /s3-mount-status/ready &&
+                  grep -Fq " ${FIFTYONE_S3_MOUNT_PATH} " /proc/mounts &&
+                  ls "${FIFTYONE_S3_MOUNT_PATH}" >/dev/null
+            periodSeconds: 60
+            timeoutSeconds: 20
+            failureThreshold: 5
           securityContext:
             privileged: true
             runAsUser: 0
@@ -200,6 +143,9 @@ spec:
               mountPath: /s3-mount-status
             - name: dev-fuse
               mountPath: /dev/fuse
+            - name: startup-scripts
+              mountPath: /opt/fiftyone-startup
+              readOnly: true
       volumes:
         - name: workspace
           persistentVolumeClaim:
@@ -214,6 +160,9 @@ spec:
           emptyDir: {}
         - name: s3-mount-status
           emptyDir: {}
+        - name: startup-scripts
+          configMap:
+            name: fiftyone-startup-scripts
         - name: dev-fuse
           hostPath:
             path: /dev/fuse

--- a/apps/annotation/base/fiftyone/fiftyone.yaml
+++ b/apps/annotation/base/fiftyone/fiftyone.yaml
@@ -102,7 +102,8 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 5
         - name: s3-datasets
-          image: rclone/rclone:1.74.2
+          image: >-
+            efrecon/s3fs:1.95@sha256:5b4078918899cca287dcc915e8e655ee526c1851e962e24df15673e6c66473d2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -121,33 +122,39 @@ spec:
 
               mkdir -p "${FIFTYONE_S3_MOUNT_PATH}"
 
+              credentials_file=/root/.passwd-s3fs
+              printf '%s:%s\n' \
+                "${AWS_ACCESS_KEY_ID}" \
+                "${AWS_SECRET_ACCESS_KEY}" > "${credentials_file}"
+              chmod 600 "${credentials_file}"
+
               # Ensure the FUSE allow_other option is configured idempotently.
               touch /etc/fuse.conf
               if ! grep -q '^user_allow_other' /etc/fuse.conf; then
                 echo 'user_allow_other' >> /etc/fuse.conf
               fi
 
-              export RCLONE_CONFIG_MLFLOW_TYPE=s3
-              export RCLONE_CONFIG_MLFLOW_PROVIDER=Ceph
-              export RCLONE_CONFIG_MLFLOW_ENV_AUTH=true
-              export RCLONE_CONFIG_MLFLOW_ENDPOINT="${MLFLOW_S3_ENDPOINT_URL}"
-              export RCLONE_CONFIG_MLFLOW_REGION=
-
-              # Exact rclone mount command: read-only, no cache/staging
-              rclone mount \
-                "mlflow:${FIFTYONE_S3_BUCKET}/${FIFTYONE_S3_PREFIX}" \
+              # Follow the FiftyOne cloud-storage guide: mount S3 as a local
+              # read-only filesystem, then let FiftyOne import from that path.
+              s3fs \
+                "${FIFTYONE_S3_BUCKET}:/${FIFTYONE_S3_PREFIX}" \
                 "${FIFTYONE_S3_MOUNT_PATH}" \
-                --read-only \
-                --allow-other \
-                --allow-non-empty \
-                --dir-cache-time 1m \
-                --poll-interval 0 \
-                --log-level INFO &
+                -f \
+                -o passwd_file="${credentials_file}" \
+                -o url="${MLFLOW_S3_ENDPOINT_URL}" \
+                -o use_path_request_style \
+                -o allow_other \
+                -o ro \
+                -o nonempty \
+                -o compat_dir \
+                -o umask=0022 \
+                -o stat_cache_expire=60 \
+                -o dbglevel=info &
 
               mount_pid="$!"
 
-              # Clean up the readiness flag and rclone process on termination.
-              trap 'rm -f /s3-mount-status/ready;
+              # Clean up the readiness flag, password file, and s3fs process.
+              trap 'rm -f /s3-mount-status/ready "${credentials_file}";
                 kill "${mount_pid}" 2>/dev/null || true' EXIT TERM INT
 
               # Verify the mount point is active and listable before startup.

--- a/apps/annotation/base/fiftyone/fiftyone.yaml
+++ b/apps/annotation/base/fiftyone/fiftyone.yaml
@@ -35,11 +35,19 @@ spec:
             ghcr.io/ai-cfia/fiftyone:1.15.0-python3.9-plugins-torch-20260604
           imagePullPolicy: IfNotPresent
           command:
-            - python
-            - -m
-            - fiftyone.server.main
-            - --port
-            - "5151"
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              echo "Waiting for S3 dataset mount..."
+              for _ in $(seq 1 90); do
+                if [ -f /s3-mount-status/ready ]; then
+                  exec python -m fiftyone.server.main --port 5151
+                fi
+                sleep 2
+              done
+              echo "Timed out waiting for S3 dataset mount" >&2
+              exit 1
           env:
             - name: FIFTYONE_DATABASE_URI
               value: mongodb://mongodb.mongodb.svc.cluster.local:27017/fiftyone
@@ -63,6 +71,12 @@ spec:
               mountPath: /ailab
             - name: datasets
               mountPath: /datasets
+            - name: s3-mount
+              mountPath: /fiftyone-s3
+              mountPropagation: HostToContainer
+            - name: s3-mount-status
+              mountPath: /s3-mount-status
+              readOnly: true
           startupProbe:
             httpGet:
               path: /
@@ -87,6 +101,97 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 5
+        - name: s3-datasets
+          image: rclone/rclone:1.74.2
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              : "${MLFLOW_S3_ENDPOINT_URL:?missing S3 endpoint URL}"
+              : "${AWS_ACCESS_KEY_ID:?missing AWS access key ID}"
+              : "${AWS_SECRET_ACCESS_KEY:?missing AWS secret access key}"
+              : "${FIFTYONE_S3_BUCKET:?missing S3 bucket}"
+              : "${FIFTYONE_S3_PREFIX:?missing S3 prefix}"
+
+              # Remove any stale readiness flags from previous runs
+              rm -f /s3-mount-status/ready
+
+              mkdir -p "${FIFTYONE_S3_MOUNT_PATH}"
+
+              # Ensure the FUSE allow_other option is configured idempotently.
+              touch /etc/fuse.conf
+              if ! grep -q '^user_allow_other' /etc/fuse.conf; then
+                echo 'user_allow_other' >> /etc/fuse.conf
+              fi
+
+              export RCLONE_CONFIG_MLFLOW_TYPE=s3
+              export RCLONE_CONFIG_MLFLOW_PROVIDER=Ceph
+              export RCLONE_CONFIG_MLFLOW_ENV_AUTH=true
+              export RCLONE_CONFIG_MLFLOW_ENDPOINT="${MLFLOW_S3_ENDPOINT_URL}"
+              export RCLONE_CONFIG_MLFLOW_REGION=
+
+              # Exact rclone mount command: read-only, no cache/staging
+              rclone mount \
+                "mlflow:${FIFTYONE_S3_BUCKET}/${FIFTYONE_S3_PREFIX}" \
+                "${FIFTYONE_S3_MOUNT_PATH}" \
+                --read-only \
+                --allow-other \
+                --dir-cache-time 1m \
+                --poll-interval 0 \
+                --log-level INFO &
+
+              mount_pid="$!"
+
+              # Clean up the readiness flag and rclone process on termination.
+              trap 'rm -f /s3-mount-status/ready;
+                kill "${mount_pid}" 2>/dev/null || true' EXIT TERM INT
+
+              # Verify the mount point is active and listable before startup.
+              for _ in $(seq 1 60); do
+                if grep -Fq " ${FIFTYONE_S3_MOUNT_PATH} " /proc/mounts &&
+                  ls "${FIFTYONE_S3_MOUNT_PATH}" >/dev/null 2>&1; then
+                  touch /s3-mount-status/ready
+                  wait "${mount_pid}"
+                fi
+                if ! kill -0 "${mount_pid}" 2>/dev/null; then
+                  wait "${mount_pid}"
+                fi
+                sleep 2
+              done
+
+              echo "S3 dataset mount did not become ready" >&2
+              kill "${mount_pid}" 2>/dev/null || true
+              exit 1
+          env:
+            - name: FIFTYONE_S3_BUCKET
+              value: mlflow
+            - name: FIFTYONE_S3_PREFIX
+              value: datasets
+            - name: FIFTYONE_S3_MOUNT_PATH
+              value: /fiftyone-s3
+          envFrom:
+            - secretRef:
+                name: fiftyone-s3-secrets
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              memory: "512Mi"
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+            - name: s3-mount
+              mountPath: /fiftyone-s3
+              mountPropagation: Bidirectional
+            - name: s3-mount-status
+              mountPath: /s3-mount-status
+            - name: dev-fuse
+              mountPath: /dev/fuse
       volumes:
         - name: workspace
           persistentVolumeClaim:
@@ -97,6 +202,14 @@ spec:
         - name: datasets
           persistentVolumeClaim:
             claimName: fiftyone-datasets-pvc
+        - name: s3-mount
+          emptyDir: {}
+        - name: s3-mount-status
+          emptyDir: {}
+        - name: dev-fuse
+          hostPath:
+            path: /dev/fuse
+            type: CharDevice
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/apps/annotation/base/fiftyone/s3-secrets.yaml
+++ b/apps/annotation/base/fiftyone/s3-secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fiftyone-s3-secrets
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: fiftyone-s3-secrets
+  dataFrom:
+    - extract:
+        key: secrets/mlflow/s3

--- a/apps/annotation/base/fiftyone/startup-scripts.yaml
+++ b/apps/annotation/base/fiftyone/startup-scripts.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fiftyone-startup-scripts
+data:
+  wait-for-s3-mount.sh: |
+    #!/bin/sh
+    set -eu
+
+    : "${FIFTYONE_S3_MOUNT_PATH:?missing S3 mount path}"
+
+    echo "Waiting for S3 dataset mount..."
+
+    for _ in $(seq 1 90); do
+      if [ -f /s3-mount-status/ready ] &&
+        grep -Fq " ${FIFTYONE_S3_MOUNT_PATH} " /proc/mounts &&
+        ls "${FIFTYONE_S3_MOUNT_PATH}" >/dev/null 2>&1; then
+        exec python -m fiftyone.server.main --port 5151
+      fi
+      sleep 2
+    done
+
+    echo "Timed out waiting for S3 dataset mount" >&2
+    exit 1
+
+  mount-s3-datasets.sh: |
+    #!/bin/sh
+    set -eu
+
+    : "${MLFLOW_S3_ENDPOINT_URL:?missing S3 endpoint URL}"
+    : "${AWS_ACCESS_KEY_ID:?missing AWS access key ID}"
+    : "${AWS_SECRET_ACCESS_KEY:?missing AWS secret access key}"
+    : "${FIFTYONE_S3_BUCKET:?missing S3 bucket}"
+    : "${FIFTYONE_S3_PREFIX:?missing S3 prefix}"
+    : "${FIFTYONE_S3_MOUNT_PATH:?missing S3 mount path}"
+
+    FIFTYONE_S3_REGION="${FIFTYONE_S3_REGION:-us-east-1}"
+    mount_pid=""
+
+    cleanup() {
+      trap - EXIT TERM INT
+      rm -f /s3-mount-status/ready
+
+      if [ -n "${mount_pid}" ]; then
+        kill "${mount_pid}" 2>/dev/null || true
+      fi
+
+      fusermount3 -u "${FIFTYONE_S3_MOUNT_PATH}" 2>/dev/null ||
+        fusermount -u "${FIFTYONE_S3_MOUNT_PATH}" 2>/dev/null ||
+        umount "${FIFTYONE_S3_MOUNT_PATH}" 2>/dev/null ||
+        umount -l "${FIFTYONE_S3_MOUNT_PATH}" 2>/dev/null ||
+        true
+
+      if [ -n "${mount_pid}" ]; then
+        wait "${mount_pid}" 2>/dev/null || true
+      fi
+    }
+
+    terminate() {
+      cleanup
+      exit 143
+    }
+
+    trap cleanup EXIT
+    trap terminate TERM INT
+
+    rm -f /s3-mount-status/ready
+    mkdir -p "${FIFTYONE_S3_MOUNT_PATH}"
+
+    # Required for the s3fs allow_other mount option.
+    touch /etc/fuse.conf
+    if ! grep -q '^user_allow_other' /etc/fuse.conf; then
+      echo 'user_allow_other' >> /etc/fuse.conf
+    fi
+
+    # Mount the S3-compatible dataset prefix as a read-only local filesystem.
+    s3fs \
+      "${FIFTYONE_S3_BUCKET}:/${FIFTYONE_S3_PREFIX}" \
+      "${FIFTYONE_S3_MOUNT_PATH}" \
+      -f \
+      -o url="${MLFLOW_S3_ENDPOINT_URL}" \
+      -o endpoint="${FIFTYONE_S3_REGION}" \
+      -o use_path_request_style \
+      -o allow_other \
+      -o ro \
+      -o nonempty \
+      -o compat_dir \
+      -o umask=0022 \
+      -o stat_cache_expire=60 \
+      -o dbglevel=info &
+
+    mount_pid="$!"
+
+    for _ in $(seq 1 60); do
+      if grep -Fq " ${FIFTYONE_S3_MOUNT_PATH} " /proc/mounts &&
+        ls "${FIFTYONE_S3_MOUNT_PATH}" >/dev/null 2>&1; then
+        touch /s3-mount-status/ready
+        wait "${mount_pid}"
+      fi
+
+      if ! kill -0 "${mount_pid}" 2>/dev/null; then
+        wait "${mount_pid}"
+      fi
+
+      sleep 2
+    done
+
+    echo "S3 dataset mount did not become ready" >&2
+    exit 1

--- a/apps/annotation/base/kustomization.yaml
+++ b/apps/annotation/base/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - labelstudio/labelstudio.yaml
   - labelstudio/certificates.yaml
   - fiftyone/fiftyone.yaml
+  - fiftyone/s3-secrets.yaml
   - httproute.yaml

--- a/apps/annotation/base/kustomization.yaml
+++ b/apps/annotation/base/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - labelstudio/certificates.yaml
   - fiftyone/fiftyone.yaml
   - fiftyone/s3-secrets.yaml
+  - fiftyone/startup-scripts.yaml
   - httproute.yaml


### PR DESCRIPTION
## Summary

Adds a read-only S3 mount to the FiftyOne pod at `/fiftyone-s3` using `s3fs-fuse`.

The existing `/datasets` CephFS mount is unchanged. FiftyOne can keep using `/datasets` as its working dataset storage, while `/fiftyone-s3` provides access to datasets stored in the shared S3-compatible storage.

## Validation

- Ran `kubectl kustomize apps/annotation/base`.
- Ran `yamllint` on the updated manifests.
- Tested locally with Garage S3 and kind.
- Confirmed the `s3fs` sidecar mounted the S3 dataset prefix.
- Confirmed another container could read files from `/fiftyone-s3`.

## Notes

The main FiftyOne container stays unprivileged. The privileged access is isolated to the `s3fs` sidecar because FUSE requires `/dev/fuse` and mount propagation.

Closes #441