### PR TITLE
Issue #446: ailab shared move seedlab container to ai-lab-3 

### DIFF
--- a/apps/ailab-shared/base/seedlab-pytorch.yaml
+++ b/apps/ailab-shared/base/seedlab-pytorch.yaml
@@ -22,7 +22,7 @@ spec:
                 - key: kubernetes.io/hostname
                   operator: In
                   values:
-                    - ai-lab-1
+                    - ai-lab-3
       imagePullSecrets:
         - name: ghcr-image-pull-secret
       containers:


### PR DESCRIPTION
Changed hostname value to ai-lab-3

Awaiting confirmation of access to /seedlab folder and nvidia-smi output for A100 